### PR TITLE
Reduce search re-renders and stabilize system tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,5 @@
 # Agent Instructions
 
 - Propose commit messages and PR titles/descriptions yourself unless explicitly provided.
+- If the example app server is not running locally, use `npm run test:dist` (which runs `npm run build:example:dist`) to build the example web `dist/` and run system tests.
+- Suggest relevant git branch names for the work when asked to create a PR or branch.

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -1,6 +1,7 @@
 import { useEvent } from 'expo';
 import HayaSelectModule, { HayaSelectView } from './haya-select-module';
 import SystemTestBrowserHelper from 'system-testing/build/system-test-browser-helper.js';
+import { PortalHost, PortalProvider } from 'conjointment';
 import OutsideEyeProvider from 'outside-eye/build/provider.js';
 import React, { useEffect } from 'react';
 import { Button, Platform, SafeAreaView, ScrollView, Text, View } from 'react-native';
@@ -22,55 +23,59 @@ export default function App() {
   }, []);
 
   return (
-    <OutsideEyeProvider>
-      <SafeAreaView
-        dataSet={{ focussed: 'true' }}
-        style={styles.container}
-        testID="systemTestingComponent"
-      >
-        <ScrollView style={styles.container}>
-          <Text testID="blankText" style={styles.blankText}>
-            {' '}
-          </Text>
-          <Text style={styles.header}>Module API Example</Text>
-          <Group name="Constants">
-            <Text>{HayaSelectModule.PI}</Text>
-          </Group>
-          <Group name="Functions">
-            <Text>{HayaSelectModule.hello()}</Text>
-          </Group>
-          <Group name="Async functions">
-            <Button
-              title="Set value"
-              onPress={async () => {
-                await HayaSelectModule.setValueAsync('Hello from JS!');
-              }}
-            />
-          </Group>
-          <Group name="Events">
-            <Text>{onChangePayload?.value}</Text>
-          </Group>
-          <Group name="Select">
-            <View testID="hayaSelectRoot">
-              <HayaSelect
-                options={[
-                  { value: 'one', text: 'One' },
-                  { value: 'two', text: 'Two' },
-                ]}
-                placeholder="Pick one"
-              />
-            </View>
-          </Group>
-          <Group name="Views">
-            <HayaSelectView
-              url="https://www.example.com"
-              onLoad={({ nativeEvent: { url } }) => console.log(`Loaded: ${url}`)}
-              style={styles.view}
-            />
-          </Group>
-        </ScrollView>
-      </SafeAreaView>
-    </OutsideEyeProvider>
+    <PortalProvider>
+      <PortalHost>
+        <OutsideEyeProvider>
+          <SafeAreaView
+            dataSet={{ focussed: 'true' }}
+            style={styles.container}
+            testID="systemTestingComponent"
+          >
+            <ScrollView style={styles.container}>
+              <Text testID="blankText" style={styles.blankText}>
+                {' '}
+              </Text>
+              <Text style={styles.header}>Module API Example</Text>
+              <Group name="Constants">
+                <Text>{HayaSelectModule.PI}</Text>
+              </Group>
+              <Group name="Functions">
+                <Text>{HayaSelectModule.hello()}</Text>
+              </Group>
+              <Group name="Async functions">
+                <Button
+                  title="Set value"
+                  onPress={async () => {
+                    await HayaSelectModule.setValueAsync('Hello from JS!');
+                  }}
+                />
+              </Group>
+              <Group name="Events">
+                <Text>{onChangePayload?.value}</Text>
+              </Group>
+              <Group name="Select">
+                <View testID="hayaSelectRoot">
+                  <HayaSelect
+                    options={[
+                      { value: 'one', text: 'One' },
+                      { value: 'two', text: 'Two' },
+                    ]}
+                    placeholder="Pick one"
+                  />
+                </View>
+              </Group>
+              <Group name="Views">
+                <HayaSelectView
+                  url="https://www.example.com"
+                  onLoad={({ nativeEvent: { url } }) => console.log(`Loaded: ${url}`)}
+                  style={styles.view}
+                />
+              </Group>
+            </ScrollView>
+          </SafeAreaView>
+        </OutsideEyeProvider>
+      </PortalHost>
+    </PortalProvider>
   );
 }
 

--- a/example/metro.config.js
+++ b/example/metro.config.js
@@ -11,6 +11,7 @@ config.resolver.blockList = [
   ...Array.from(config.resolver.blockList ?? []),
   new RegExp(path.resolve('..', 'node_modules', 'react')),
   new RegExp(path.resolve('..', 'node_modules', 'react-native')),
+  new RegExp(path.resolve(__dirname, 'node_modules', 'conjointment')),
 ];
 
 config.resolver.nodeModulesPaths = [
@@ -20,6 +21,7 @@ config.resolver.nodeModulesPaths = [
 
 config.resolver.extraNodeModules = {
   'haya-select': '..',
+  conjointment: path.resolve(__dirname, '../node_modules/conjointment'),
 };
 
 config.watchFolders = [path.resolve(__dirname, '..')];

--- a/package.json
+++ b/package.json
@@ -9,9 +9,11 @@
   "types": "build/index.d.ts",
   "scripts": {
     "build": "expo-module build",
+    "build:example:dist": "EXPO_NONINTERACTIVE=1 cd example && npx expo export --platform web --output-dir ../dist",
     "clean": "expo-module clean",
     "lint": "expo-module lint",
     "test": "node scripts/velocious-test.js",
+    "test:dist": "npm run build:example:dist && SYSTEM_TEST_HOST=dist npm test",
     "prepare": "expo-module prepare",
     "prepublishOnly": "expo-module prepublishOnly",
     "open:ios": "xed example/ios",

--- a/spec/system/haya-select-render-spec.js
+++ b/spec/system/haya-select-render-spec.js
@@ -1,6 +1,7 @@
 import "velocious/build/src/testing/test.js";
 import SystemTest from "system-testing/build/system-test.js";
 import timeout from "awaitery/build/timeout.js";
+import waitFor from "awaitery/build/wait-for.js";
 
 SystemTest.rootPath = "/?systemTest=true";
 const systemTestArgs = {};
@@ -24,6 +25,27 @@ describe("HayaSelect", () => {
     await timeout({timeout: 90000}, async () => {
       await SystemTest.run(systemTestArgs, async (systemTest) => {
         await systemTest.findByTestID("hayaSelectRoot", {timeout: 60000});
+      });
+    });
+  });
+
+  it("filters options when searching", async () => {
+    await timeout({timeout: 90000}, async () => {
+      await SystemTest.run(systemTestArgs, async (systemTest) => {
+        await systemTest.findByTestID("hayaSelectRoot", {timeout: 60000});
+        await systemTest.click("[data-class='select-container']");
+
+        const searchInput = await systemTest.find("[data-class='search-text-input']");
+        await systemTest.interact(searchInput, "sendKeys", "tw");
+
+        await waitFor({timeout: 5000}, async () => {
+          const options = await systemTest.all("[data-class='select-option']", {useBaseSelector: false});
+          const texts = await Promise.all(options.map(async (option) => (await option.getText()).trim()));
+
+          if (texts.length !== 1 || texts[0] !== "Two") {
+            throw new Error(`Unexpected options: ${texts.join(", ")}`);
+          }
+        });
       });
     });
   });


### PR DESCRIPTION
- Make search input uncontrolled to cut re-renders.
- Add system test for search filtering.
- Ensure portal host setup in the example app and pin conjointment resolution in Metro.
- Add build:example:dist and update test:dist; document local test guidance.