### PR TITLE
Fix select options width after layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,4 @@
 ## Unreleased
 - Fix crash when opening the select before layout measurements are available.
 - Update options width when layout data arrives after opening.
+- Guard options positioning until layout data is available.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## Unreleased
+- Fix crash when opening the select before layout measurements are available.
+- Update options width when layout data arrives after opening.

--- a/src/select/index.jsx
+++ b/src/select/index.jsx
@@ -487,7 +487,11 @@ export default memo(shapeComponent(class HayaSelect extends ShapeComponent {
       newState.optionsWidth = endOfSelectLayout.width
     }
 
-    this.setState(newState)
+    this.setState(newState, () => {
+      if (this.s.opened && this.s.optionsContainerLayout) {
+        this.setOptionsPositionAboveIfOutsideScreen()
+      }
+    })
   }
   onOptionsContainerLayout = (e) => this.setState({optionsContainerLayout: Object.assign({}, digg(e, "nativeEvent", "layout"))})
 
@@ -580,7 +584,14 @@ export default memo(shapeComponent(class HayaSelect extends ShapeComponent {
   setOptionsPositionAboveIfOutsideScreen() {
     const {windowHeight} = this.tt
     const {optionsContainerLayout} = this.s
-    const optionsTop = this.s.endOfSelectLayout.top
+    const endOfSelectLayout = this.s.endOfSelectLayout
+
+    if (!endOfSelectLayout) {
+      this.setState({optionsVisibility: "visible"})
+      return
+    }
+
+    const optionsTop = endOfSelectLayout.top
     const optionsTotalBottomPosition = optionsContainerLayout.height + optionsTop
     const windowHeightWithScroll = windowHeight + this.s.scrollTop
 

--- a/src/select/index.jsx
+++ b/src/select/index.jsx
@@ -479,7 +479,16 @@ export default memo(shapeComponent(class HayaSelect extends ShapeComponent {
   }
 
   onSelectContainerLayout = (e) => this.setState({selectContainerLayout: Object.assign({}, digg(e, "nativeEvent", "layout"))})
-  onEndOfSelectLayout = (e) => this.setState({endOfSelectLayout: Object.assign({}, digg(e, "nativeEvent", "layout"))})
+  onEndOfSelectLayout = (e) => {
+    const endOfSelectLayout = Object.assign({}, digg(e, "nativeEvent", "layout"))
+    const newState = {endOfSelectLayout}
+
+    if (this.s.opened && endOfSelectLayout?.width) {
+      newState.optionsWidth = endOfSelectLayout.width
+    }
+
+    this.setState(newState)
+  }
   onOptionsContainerLayout = (e) => this.setState({optionsContainerLayout: Object.assign({}, digg(e, "nativeEvent", "layout"))})
 
   onSelectClicked = (e) => {
@@ -590,7 +599,7 @@ export default memo(shapeComponent(class HayaSelect extends ShapeComponent {
         opened: true,
         optionsPlacement: "above",
         optionsVisibility: "visible",
-        optionsWidth: endOfSelectLayout.width
+        optionsWidth: endOfSelectLayout?.width
       },
       () => this.focusTextInput()
     )
@@ -602,7 +611,7 @@ export default memo(shapeComponent(class HayaSelect extends ShapeComponent {
         opened: true,
         optionsPlacement: "below",
         optionsVisibility: "hidden",
-        optionsWidth: this.s.endOfSelectLayout.width
+        optionsWidth: this.s.endOfSelectLayout?.width
       },
       () => this.focusTextInput()
     )


### PR DESCRIPTION
## Summary
- update options width when layout arrives while opened
- guard width access when layout is not yet available
- document change in changelog

## Testing
- not run (not requested)
