### PR TITLE
Add optionContent coverage and system test helpers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,3 +6,4 @@
 - Avoid ending JavaScript lines with semicolons unless required for correctness.
 - For scoundrel evals that return data, use an explicit `return` statement inside the eval.
 - Suggest relevant git branch names for the work when asked to create a PR or branch.
+- In this repo, do not use `.browser-spec.js` suffix; keep specs named with the standard `*-spec.js` pattern.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,3 +20,10 @@
 - Reset pagination page state on close to avoid stale page size inference.
 - Stabilize pagination system specs for manual entry and navigation.
 - Use scoundrel clicks in pagination specs to reduce selector flakiness.
+- Ensure pagination specs assert that option lists change with page.
+- Extract pagination system specs into a dedicated browser spec file.
+- Rename pagination spec to standard `*-spec.js` naming for this repo.
+- Clarify that options may include extra props beyond those HayaSelect uses.
+- Add `optionContent` callback support for custom option rendering.
+- Add system spec coverage for optionContent rendering.
+- Avoid starting/stopping system tests multiple times across spec files.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,3 +32,6 @@
 - Validate HayaSelect system test helper options to reject unexpected keys.
 - Validate selectOption criteria to reject unexpected keys.
 - Align optionContent selected flag with loose equality behavior.
+- Support `right` option content aligned with option text.
+- Add system spec coverage for right option content.
+- Scope system test helper option queries to the active options container.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,3 +31,4 @@
 - Move system test helpers into src for consumer access.
 - Validate HayaSelect system test helper options to reject unexpected keys.
 - Validate selectOption criteria to reject unexpected keys.
+- Align optionContent selected flag with loose equality behavior.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,3 +27,7 @@
 - Add `optionContent` callback support for custom option rendering.
 - Add system spec coverage for optionContent rendering.
 - Avoid starting/stopping system tests multiple times across spec files.
+- Add a shared HayaSelect system test helper and reuse it in specs.
+- Move system test helpers into src for consumer access.
+- Validate HayaSelect system test helper options to reject unexpected keys.
+- Validate selectOption criteria to reject unexpected keys.

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -18,6 +18,10 @@ export default function App() {
     {value: "two", text: "Two"},
     {value: "three", text: "Three"}
   ]
+  const rightSelectOptions = selectOptions.map((option) => ({
+    ...option,
+    right: <Text>Right {option.text}</Text>
+  }))
   const paginationPageSize = 5
   const paginationTotalCount = 24
 
@@ -88,6 +92,14 @@ export default function App() {
                   <HayaSelect
                     options={selectOptions}
                     placeholder="Pick one"
+                  />
+                </View>
+              </Group>
+              <Group name="Right Option Select">
+                <View testID="hayaSelectRightOptionRoot">
+                  <HayaSelect
+                    options={rightSelectOptions}
+                    placeholder="Pick with right"
                   />
                 </View>
               </Group>

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -91,6 +91,19 @@ export default function App() {
                   />
                 </View>
               </Group>
+              <Group name="Option Content Select">
+                <View testID="hayaSelectOptionContentRoot">
+                  <HayaSelect
+                    optionContent={({option}) => (
+                      <Text>
+                        Custom {option.text}
+                      </Text>
+                    )}
+                    options={selectOptions}
+                    placeholder="Pick custom"
+                  />
+                </View>
+              </Group>
               <Group name="Multiple Select">
                 <View testID="hayaSelectMultipleRoot">
                   <HayaSelect

--- a/spec/system/haya-select-pagination-spec.js
+++ b/spec/system/haya-select-pagination-spec.js
@@ -1,0 +1,222 @@
+import "velocious/build/src/testing/test.js"
+import timeout from "awaitery/build/timeout.js"
+import waitFor from "awaitery/build/wait-for.js"
+import SystemTest from "system-testing/build/system-test.js"
+
+SystemTest.rootPath = "/?systemTest=true"
+const systemTestArgs = {debug: true}
+let didStartSystemTest = false
+
+beforeAll(async () => {
+  const systemTest = SystemTest.current(systemTestArgs)
+  if (!systemTest.isStarted()) {
+    await timeout({timeout: 90000}, async () => {
+      await systemTest.start()
+    })
+    didStartSystemTest = true
+  }
+  systemTest.setBaseSelector("[data-testid='systemTestingComponent']")
+})
+
+afterAll(async () => {
+  if (!didStartSystemTest) return
+
+  await timeout({timeout: 120000}, async () => {
+    await SystemTest.current().stop()
+  })
+})
+
+const openPaginatedSelect = async (systemTest) => {
+  const scoundrel = await systemTest.getScoundrelClient()
+  const isOpen = await scoundrel.evalResult(`
+    return Boolean(document.querySelector("[data-testid='hayaSelectPaginationRoot'] [data-class='search-text-input']"))
+  `)
+
+  if (!isOpen) {
+    await systemTest.click("[data-testid='hayaSelectPaginationRoot'] [data-class='select-container']")
+    await systemTest.find("[data-testid='hayaSelectPaginationRoot'] [data-class='search-text-input']")
+  }
+
+  await waitFor({timeout: 5000}, async () => {
+    const paginationVisible = await scoundrel.evalResult(`
+      return Boolean(document.querySelector("[data-class='options-pagination']"))
+    `)
+
+    if (!paginationVisible) {
+      throw new Error("Pagination not visible yet")
+    }
+  })
+
+  const labelText = await scoundrel.evalResult(`
+    const label = document.querySelector("[data-class='pagination-label']")
+    return label ? label.textContent.trim() : null
+  `)
+
+  if (labelText && !labelText.startsWith("Page 1 of ")) {
+    const pageOne = await findPaginationPageButton(systemTest, 1)
+    await systemTest.click(pageOne)
+  }
+
+  await waitForPaginationLabel(systemTest, "Page 1 of 5")
+}
+
+const closePaginatedSelect = async (systemTest) => {
+  const scoundrel = await systemTest.getScoundrelClient()
+  const isOpen = await scoundrel.evalResult(`
+    return Boolean(document.querySelector("[data-testid='hayaSelectPaginationRoot'] [data-class='search-text-input']"))
+  `)
+
+  if (isOpen) {
+    await systemTest.click("[data-testid='hayaSelectPaginationRoot'] [data-class='select-container']")
+  }
+}
+
+const paginationLabelText = async (systemTest) => {
+  const scoundrel = await systemTest.getScoundrelClient()
+
+  return await scoundrel.evalResult(`
+    const element = document.querySelector("[data-class='pagination-label']")
+    return element ? element.textContent.trim() : null
+  `)
+}
+
+const waitForPaginationLabel = async (systemTest, expectedText) => {
+  await waitFor({timeout: 5000}, async () => {
+    const labelText = await paginationLabelText(systemTest)
+
+    if (labelText !== expectedText) {
+      throw new Error(`Unexpected pagination label: ${labelText}`)
+    }
+  })
+}
+
+const findPaginationPageButton = async (systemTest, pageNumber) => {
+  let matchingButton
+
+  await waitFor({timeout: 5000}, async () => {
+    const pageButtons = await systemTest.all("[data-class='pagination-page']", {useBaseSelector: false})
+
+    for (const pageButton of pageButtons) {
+      const buttonText = (await pageButton.getText()).trim()
+
+      if (buttonText === String(pageNumber)) {
+        matchingButton = pageButton
+        return
+      }
+    }
+
+    throw new Error(`Pagination button not found for page ${pageNumber}`)
+  })
+
+  return matchingButton
+}
+
+const optionTexts = async (systemTest) => {
+  const options = await systemTest.all("[data-class='select-option']", {useBaseSelector: false})
+
+  return await Promise.all(options.map(async (option) => (await option.getText()).trim()))
+}
+
+const clickPaginationSelector = async (systemTest, selector) => {
+  const scoundrel = await systemTest.getScoundrelClient()
+
+  await waitFor({timeout: 5000}, async () => {
+    const clicked = await scoundrel.evalResult(`
+      const element = document.querySelector(${JSON.stringify(selector)})
+      if (!element) return false
+      element.click()
+      return true
+    `)
+
+    if (!clicked) {
+      throw new Error(`Pagination element not ready for selector: ${selector}`)
+    }
+  })
+}
+
+describe("HayaSelect pagination", () => {
+  afterEach(async () => {
+    await timeout({timeout: 90000}, async () => {
+      await SystemTest.run(systemTestArgs, async (systemTest) => {
+        await closePaginatedSelect(systemTest)
+      })
+    })
+  })
+
+  it("changes page when clicking a page number", async () => {
+    await timeout({timeout: 90000}, async () => {
+      await SystemTest.run(systemTestArgs, async (systemTest) => {
+        await systemTest.findByTestID("hayaSelectPaginationRoot", {timeout: 60000})
+        await openPaginatedSelect(systemTest)
+
+        const pageTwo = await findPaginationPageButton(systemTest, 2)
+        await systemTest.click(pageTwo)
+
+        await waitForPaginationLabel(systemTest, "Page 2 of 5")
+        await waitFor({timeout: 5000}, async () => {
+          const texts = await optionTexts(systemTest)
+
+          if (!texts[0]?.startsWith("Page 2 Item 6")) {
+            throw new Error(`Unexpected first option text: ${texts[0]}`)
+          }
+        })
+      })
+    })
+  })
+
+  it("accepts manual page entry from the pagination label", async () => {
+    await timeout({timeout: 90000}, async () => {
+      await SystemTest.run(systemTestArgs, async (systemTest) => {
+        await systemTest.findByTestID("hayaSelectPaginationRoot", {timeout: 60000})
+        await openPaginatedSelect(systemTest)
+
+        await clickPaginationSelector(systemTest, "[data-class='pagination-label']")
+        const paginationInput = await systemTest.find("[data-class='pagination-input']", {useBaseSelector: false, timeout: 5000})
+        await systemTest.interact(paginationInput, "click")
+        await systemTest.interact(paginationInput, "sendKeys", "\uE009a")
+        await systemTest.interact(paginationInput, "sendKeys", "\uE003")
+        await systemTest.interact(paginationInput, "sendKeys", "4")
+        await systemTest.interact(paginationInput, "sendKeys", "\uE006")
+
+        await waitForPaginationLabel(systemTest, "Page 4 of 5")
+        await waitFor({timeout: 5000}, async () => {
+          const texts = await optionTexts(systemTest)
+
+          if (!texts[0]?.startsWith("Page 4 Item 16")) {
+            throw new Error(`Unexpected first option text: ${texts[0]}`)
+          }
+        })
+      })
+    })
+  })
+
+  it("supports next and previous pagination buttons", async () => {
+    await timeout({timeout: 90000}, async () => {
+      await SystemTest.run(systemTestArgs, async (systemTest) => {
+        await systemTest.findByTestID("hayaSelectPaginationRoot", {timeout: 60000})
+        await openPaginatedSelect(systemTest)
+        await waitForPaginationLabel(systemTest, "Page 1 of 5")
+
+        await clickPaginationSelector(systemTest, "[data-class='pagination-next']")
+        await waitForPaginationLabel(systemTest, "Page 2 of 5")
+        await waitFor({timeout: 5000}, async () => {
+          const texts = await optionTexts(systemTest)
+
+          if (!texts[0]?.startsWith("Page 2 Item 6")) {
+            throw new Error(`Unexpected first option text: ${texts[0]}`)
+          }
+        })
+
+        await clickPaginationSelector(systemTest, "[data-class='pagination-prev']")
+        await waitForPaginationLabel(systemTest, "Page 1 of 5")
+        await waitFor({timeout: 5000}, async () => {
+          const texts = await optionTexts(systemTest)
+
+          if (!texts[0]?.startsWith("Page 1 Item 1")) {
+            throw new Error(`Unexpected first option text: ${texts[0]}`)
+          }
+        })
+      })
+    })
+  })
+})

--- a/spec/system/haya-select-pagination-spec.js
+++ b/spec/system/haya-select-pagination-spec.js
@@ -3,6 +3,8 @@ import timeout from "awaitery/build/timeout.js"
 import waitFor from "awaitery/build/wait-for.js"
 import SystemTest from "system-testing/build/system-test.js"
 
+import HayaSelectSystemTestHelper from "../../src/system-test-helpers.js"
+
 SystemTest.rootPath = "/?systemTest=true"
 const systemTestArgs = {debug: true}
 let didStartSystemTest = false
@@ -111,12 +113,6 @@ const findPaginationPageButton = async (systemTest, pageNumber) => {
   return matchingButton
 }
 
-const optionTexts = async (systemTest) => {
-  const options = await systemTest.all("[data-class='select-option']", {useBaseSelector: false})
-
-  return await Promise.all(options.map(async (option) => (await option.getText()).trim()))
-}
-
 const clickPaginationSelector = async (systemTest, selector) => {
   const scoundrel = await systemTest.getScoundrelClient()
 
@@ -146,6 +142,8 @@ describe("HayaSelect pagination", () => {
   it("changes page when clicking a page number", async () => {
     await timeout({timeout: 90000}, async () => {
       await SystemTest.run(systemTestArgs, async (systemTest) => {
+        const helper = new HayaSelectSystemTestHelper({systemTest, testId: "hayaSelectPaginationRoot"})
+
         await systemTest.findByTestID("hayaSelectPaginationRoot", {timeout: 60000})
         await openPaginatedSelect(systemTest)
 
@@ -154,7 +152,7 @@ describe("HayaSelect pagination", () => {
 
         await waitForPaginationLabel(systemTest, "Page 2 of 5")
         await waitFor({timeout: 5000}, async () => {
-          const texts = await optionTexts(systemTest)
+          const texts = await helper.optionTexts()
 
           if (!texts[0]?.startsWith("Page 2 Item 6")) {
             throw new Error(`Unexpected first option text: ${texts[0]}`)
@@ -167,6 +165,8 @@ describe("HayaSelect pagination", () => {
   it("accepts manual page entry from the pagination label", async () => {
     await timeout({timeout: 90000}, async () => {
       await SystemTest.run(systemTestArgs, async (systemTest) => {
+        const helper = new HayaSelectSystemTestHelper({systemTest, testId: "hayaSelectPaginationRoot"})
+
         await systemTest.findByTestID("hayaSelectPaginationRoot", {timeout: 60000})
         await openPaginatedSelect(systemTest)
 
@@ -180,7 +180,7 @@ describe("HayaSelect pagination", () => {
 
         await waitForPaginationLabel(systemTest, "Page 4 of 5")
         await waitFor({timeout: 5000}, async () => {
-          const texts = await optionTexts(systemTest)
+          const texts = await helper.optionTexts()
 
           if (!texts[0]?.startsWith("Page 4 Item 16")) {
             throw new Error(`Unexpected first option text: ${texts[0]}`)
@@ -193,6 +193,8 @@ describe("HayaSelect pagination", () => {
   it("supports next and previous pagination buttons", async () => {
     await timeout({timeout: 90000}, async () => {
       await SystemTest.run(systemTestArgs, async (systemTest) => {
+        const helper = new HayaSelectSystemTestHelper({systemTest, testId: "hayaSelectPaginationRoot"})
+
         await systemTest.findByTestID("hayaSelectPaginationRoot", {timeout: 60000})
         await openPaginatedSelect(systemTest)
         await waitForPaginationLabel(systemTest, "Page 1 of 5")
@@ -200,7 +202,7 @@ describe("HayaSelect pagination", () => {
         await clickPaginationSelector(systemTest, "[data-class='pagination-next']")
         await waitForPaginationLabel(systemTest, "Page 2 of 5")
         await waitFor({timeout: 5000}, async () => {
-          const texts = await optionTexts(systemTest)
+          const texts = await helper.optionTexts()
 
           if (!texts[0]?.startsWith("Page 2 Item 6")) {
             throw new Error(`Unexpected first option text: ${texts[0]}`)
@@ -210,7 +212,7 @@ describe("HayaSelect pagination", () => {
         await clickPaginationSelector(systemTest, "[data-class='pagination-prev']")
         await waitForPaginationLabel(systemTest, "Page 1 of 5")
         await waitFor({timeout: 5000}, async () => {
-          const texts = await optionTexts(systemTest)
+          const texts = await helper.optionTexts()
 
           if (!texts[0]?.startsWith("Page 1 Item 1")) {
             throw new Error(`Unexpected first option text: ${texts[0]}`)

--- a/spec/system/haya-select-render-spec.js
+++ b/spec/system/haya-select-render-spec.js
@@ -5,136 +5,62 @@ import SystemTest from "system-testing/build/system-test.js"
 
 SystemTest.rootPath = "/?systemTest=true"
 const systemTestArgs = {debug: true}
+let didStartSystemTest = false
 
 beforeAll(async () => {
   const systemTest = SystemTest.current(systemTestArgs)
-  await timeout({timeout: 90000}, async () => {
-    await systemTest.start()
-  })
+  if (!systemTest.isStarted()) {
+    await timeout({timeout: 90000}, async () => {
+      await systemTest.start()
+    })
+    didStartSystemTest = true
+  }
   systemTest.setBaseSelector("[data-testid='systemTestingComponent']")
 })
 
 afterAll(async () => {
+  if (!didStartSystemTest) return
+
   await timeout({timeout: 120000}, async () => {
     await SystemTest.current().stop()
   })
 })
 
-const openPaginatedSelect = async (systemTest) => {
-  const scoundrel = await systemTest.getScoundrelClient()
-  const isOpen = await scoundrel.evalResult(`
-    return Boolean(document.querySelector("[data-testid='hayaSelectPaginationRoot'] [data-class='search-text-input']"))
-  `)
-
-  if (!isOpen) {
-    await systemTest.click("[data-testid='hayaSelectPaginationRoot'] [data-class='select-container']")
-    await systemTest.find("[data-testid='hayaSelectPaginationRoot'] [data-class='search-text-input']")
-  }
-
-  await waitFor({timeout: 5000}, async () => {
-    const paginationVisible = await scoundrel.evalResult(`
-      return Boolean(document.querySelector("[data-class='options-pagination']"))
-    `)
-
-    if (!paginationVisible) {
-      throw new Error("Pagination not visible yet")
-    }
-  })
-
-  const labelText = await scoundrel.evalResult(`
-    const label = document.querySelector("[data-class='pagination-label']")
-    return label ? label.textContent.trim() : null
-  `)
-
-  if (labelText && !labelText.startsWith("Page 1 of ")) {
-    const pageOne = await findPaginationPageButton(systemTest, 1)
-    await systemTest.click(pageOne)
-  }
-
-  await waitForPaginationLabel(systemTest, "Page 1 of 5")
-}
-
-const closePaginatedSelect = async (systemTest) => {
-  const scoundrel = await systemTest.getScoundrelClient()
-  const isOpen = await scoundrel.evalResult(`
-    return Boolean(document.querySelector("[data-testid='hayaSelectPaginationRoot'] [data-class='search-text-input']"))
-  `)
-
-  if (isOpen) {
-    await systemTest.click("[data-testid='hayaSelectPaginationRoot'] [data-class='select-container']")
-  }
-}
-
-const paginationLabelText = async (systemTest) => {
-  const scoundrel = await systemTest.getScoundrelClient()
-
-  return await scoundrel.evalResult(`
-    const element = document.querySelector("[data-class='pagination-label']")
-    return element ? element.textContent.trim() : null
-  `)
-}
-
-const clickPaginationSelector = async (systemTest, selector) => {
-  const scoundrel = await systemTest.getScoundrelClient()
-
-  await waitFor({timeout: 5000}, async () => {
-    const clicked = await scoundrel.evalResult(`
-      const element = document.querySelector(${JSON.stringify(selector)})
-      if (!element) return false
-      element.click()
-      return true
-    `)
-
-    if (!clicked) {
-      throw new Error(`Pagination element not ready for selector: ${selector}`)
-    }
-  })
-}
-
-const waitForPaginationLabel = async (systemTest, expectedText) => {
-  await waitFor({timeout: 5000}, async () => {
-    const labelText = await paginationLabelText(systemTest)
-
-    if (labelText !== expectedText) {
-      throw new Error(`Unexpected pagination label: ${labelText}`)
-    }
-  })
-}
-
-const findPaginationPageButton = async (systemTest, pageNumber) => {
-  let matchingButton
-
-  await waitFor({timeout: 5000}, async () => {
-    const pageButtons = await systemTest.all("[data-class='pagination-page']", {useBaseSelector: false})
-
-    for (const pageButton of pageButtons) {
-      const buttonText = (await pageButton.getText()).trim()
-
-      if (buttonText === String(pageNumber)) {
-        matchingButton = pageButton
-        return
-      }
-    }
-
-    throw new Error(`Pagination button not found for page ${pageNumber}`)
-  })
-
-  return matchingButton
-}
-
 describe("HayaSelect", () => {
-  afterEach(async () => {
-    await timeout({timeout: 90000}, async () => {
-      await SystemTest.run(systemTestArgs, async (systemTest) => {
-        await closePaginatedSelect(systemTest)
-      })
-    })
-  })
-
   it("renders in the example app", async () => {
     await timeout({timeout: 90000}, async () => {
       await SystemTest.run(systemTestArgs, async (systemTest) => {
         await systemTest.findByTestID("hayaSelectRoot", {timeout: 60000})
+      })
+    })
+  })
+
+  it("renders optionContent callbacks", async () => {
+    await timeout({timeout: 90000}, async () => {
+      await SystemTest.run(systemTestArgs, async (systemTest) => {
+        await systemTest.findByTestID("hayaSelectOptionContentRoot", {timeout: 60000})
+        await systemTest.click("[data-testid='hayaSelectOptionContentRoot'] [data-class='select-container']")
+
+        await waitFor({timeout: 5000}, async () => {
+          const options = await systemTest.all("[data-class='select-option']", {useBaseSelector: false})
+          const texts = await Promise.all(options.map(async (option) => (await option.getText()).trim()))
+
+          if (!texts.includes("Custom One")) {
+            throw new Error(`Unexpected option content: ${texts.join(", ")}`)
+          }
+        })
+
+        await systemTest.click("[data-testid='hayaSelectOptionContentRoot'] [data-class='select-container']")
+        await waitFor({timeout: 5000}, async () => {
+          const searchInputs = await systemTest.all(
+            "[data-testid='hayaSelectOptionContentRoot'] [data-class='search-text-input']",
+            {timeout: 0, visible: false}
+          )
+
+          if (searchInputs.length > 0) {
+            throw new Error("Search input is still visible")
+          }
+        })
       })
     })
   })
@@ -294,66 +220,4 @@ describe("HayaSelect", () => {
     })
   })
 
-  it("changes page when clicking a page number", async () => {
-    await timeout({timeout: 90000}, async () => {
-      await SystemTest.run(systemTestArgs, async (systemTest) => {
-        await systemTest.findByTestID("hayaSelectPaginationRoot", {timeout: 60000})
-        await openPaginatedSelect(systemTest)
-
-        const pageTwo = await findPaginationPageButton(systemTest, 2)
-        await systemTest.click(pageTwo)
-
-        await waitFor({timeout: 5000}, async () => {
-          const labelText = await paginationLabelText(systemTest)
-          if (labelText !== "Page 2 of 5") {
-            throw new Error(`Unexpected pagination label: ${labelText}`)
-          }
-        })
-
-        await waitFor({timeout: 5000}, async () => {
-          const options = await systemTest.all("[data-class='select-option']", {useBaseSelector: false})
-          const texts = await Promise.all(options.map(async (option) => (await option.getText()).trim()))
-
-          if (!texts[0]?.startsWith("Page 2 Item 6")) {
-            throw new Error(`Unexpected first option text: ${texts[0]}`)
-          }
-        })
-      })
-    })
-  })
-
-  it("accepts manual page entry from the pagination label", async () => {
-    await timeout({timeout: 90000}, async () => {
-      await SystemTest.run(systemTestArgs, async (systemTest) => {
-        await systemTest.findByTestID("hayaSelectPaginationRoot", {timeout: 60000})
-        await openPaginatedSelect(systemTest)
-
-        await clickPaginationSelector(systemTest, "[data-class='pagination-label']")
-        const paginationInput = await systemTest.find("[data-class='pagination-input']", {useBaseSelector: false, timeout: 5000})
-        await systemTest.interact(paginationInput, "click")
-        await systemTest.interact(paginationInput, "sendKeys", "\uE009a")
-        await systemTest.interact(paginationInput, "sendKeys", "\uE003")
-        await systemTest.interact(paginationInput, "sendKeys", "4")
-        await systemTest.interact(paginationInput, "sendKeys", "\uE006")
-
-        await waitForPaginationLabel(systemTest, "Page 4 of 5")
-      })
-    })
-  })
-
-  it("supports next and previous pagination buttons", async () => {
-    await timeout({timeout: 90000}, async () => {
-      await SystemTest.run(systemTestArgs, async (systemTest) => {
-        await systemTest.findByTestID("hayaSelectPaginationRoot", {timeout: 60000})
-        await openPaginatedSelect(systemTest)
-        await waitForPaginationLabel(systemTest, "Page 1 of 5")
-
-        await clickPaginationSelector(systemTest, "[data-class='pagination-next']")
-        await waitForPaginationLabel(systemTest, "Page 2 of 5")
-
-        await clickPaginationSelector(systemTest, "[data-class='pagination-prev']")
-        await waitForPaginationLabel(systemTest, "Page 1 of 5")
-      })
-    })
-  })
 })

--- a/spec/system/haya-select-render-spec.js
+++ b/spec/system/haya-select-render-spec.js
@@ -58,6 +58,27 @@ describe("HayaSelect", () => {
     })
   })
 
+  it("renders right option content", async () => {
+    await timeout({timeout: 90000}, async () => {
+      await SystemTest.run(systemTestArgs, async (systemTest) => {
+        const helper = new HayaSelectSystemTestHelper({systemTest, testId: "hayaSelectRightOptionRoot"})
+
+        await systemTest.findByTestID("hayaSelectRightOptionRoot", {timeout: 60000})
+        await helper.open()
+
+        await waitFor({timeout: 5000}, async () => {
+          const texts = await helper.optionTexts()
+
+          if (!texts.some((text) => text.includes("Right One"))) {
+            throw new Error(`Unexpected right option content: ${texts.join(", ")}`)
+          }
+        })
+
+        await helper.close()
+      })
+    })
+  })
+
   it("filters options when searching", async () => {
     await timeout({timeout: 90000}, async () => {
       await SystemTest.run(systemTestArgs, async (systemTest) => {
@@ -72,7 +93,7 @@ describe("HayaSelect", () => {
         await waitFor({timeout: 5000}, async () => {
           const texts = await helper.optionTexts()
 
-          if (texts.length !== 1 || texts[0] !== "Two") {
+          if (texts.length !== 1 || !texts[0].includes("Two")) {
             throw new Error(`Unexpected options: ${texts.join(", ")}`)
           }
         })
@@ -94,11 +115,8 @@ describe("HayaSelect", () => {
           await systemTest.find("[data-class='select-option'][data-value='one']", {useBaseSelector: false})
         })
 
-        const optionOne = await systemTest.find("[data-class='select-option'][data-value='one']", {useBaseSelector: false})
-        await systemTest.click(optionOne)
-
-        const optionTwo = await systemTest.find("[data-class='select-option'][data-value='two']", {useBaseSelector: false})
-        await systemTest.click(optionTwo)
+        await helper.selectOption({value: "one"})
+        await helper.selectOption({value: "two"})
 
         const scoundrel = await systemTest.getScoundrelClient()
         const colors = await scoundrel.evalResult(`

--- a/src/select/index.jsx
+++ b/src/select/index.jsx
@@ -38,6 +38,8 @@ const paginationButtonStyles = {}
  * @property {function(): import("react").ReactNode} [currentContent]
  * @property {boolean} [disabled]
  * @property {string} [html]
+ *
+ * Additional option props are allowed; HayaSelect only uses the keys above.
  */
 
 /**
@@ -66,6 +68,7 @@ const paginationButtonStyles = {}
  * @property {function(Array<string|number>=): void} [onChangeValue]
  * @property {function(import("react").SyntheticEvent=): void} [onFocus]
  * @property {function(): void} [onOptionsClosed]
+ * @property {function(object): import("react").ReactNode} [optionContent]
  * @property {Array<HayaSelectOption>|function(): (Array<HayaSelectOption>|HayaSelectOptionsResult)} options
  * @property {boolean} optionsAbsolute
  * @property {boolean} optionsPortal
@@ -178,6 +181,7 @@ export default memo(shapeComponent(class HayaSelect extends ShapeComponent {
     onChangeValue: PropTypes.func,
     onFocus: PropTypes.func,
     onOptionsClosed: PropTypes.func,
+    optionContent: PropTypes.func,
     options: PropTypes.oneOfType([
       PropTypes.arrayOf(PropTypes.shape({
         content: PropTypes.func,
@@ -1350,11 +1354,12 @@ export default memo(shapeComponent(class HayaSelect extends ShapeComponent {
   }
 
   presentOption = (option, mode) => {
-    const {toggleOptions} = this.props || {}
+    const {optionContent, toggleOptions} = this.props || {}
     const toggled = this.getToggled()
     const icon = this.iconForOption(option)
     const toggleValue = toggled[option.value]
     const toggleOption = toggleOptions?.find((toggleOptionI) => toggleOptionI.value == toggleValue)
+    const selected = this.getCurrentOptionValues().includes(option.value)
     let style
 
     if (mode == "current") {
@@ -1389,7 +1394,9 @@ export default memo(shapeComponent(class HayaSelect extends ShapeComponent {
           </View>
         }
         {(() => {
-          if (mode == "current" && option.currentContent) {
+          if (optionContent) {
+            return optionContent({icon, mode, option, selected, toggleOption, toggleValue, toggled})
+          } else if (mode == "current" && option.currentContent) {
             return option.currentContent()
           } else if (option.content) {
             return option.content()

--- a/src/select/index.jsx
+++ b/src/select/index.jsx
@@ -1359,7 +1359,7 @@ export default memo(shapeComponent(class HayaSelect extends ShapeComponent {
     const icon = this.iconForOption(option)
     const toggleValue = toggled[option.value]
     const toggleOption = toggleOptions?.find((toggleOptionI) => toggleOptionI.value == toggleValue)
-    const selected = this.getCurrentOptionValues().includes(option.value)
+    const selected = this.getCurrentOptionValues().some((value) => value == option.value)
     let style
 
     if (mode == "current") {

--- a/src/select/index.jsx
+++ b/src/select/index.jsx
@@ -38,6 +38,7 @@ const paginationButtonStyles = {}
  * @property {function(): import("react").ReactNode} [currentContent]
  * @property {boolean} [disabled]
  * @property {string} [html]
+ * @property {import("react").ReactNode} [right]
  *
  * Additional option props are allowed; HayaSelect only uses the keys above.
  */
@@ -188,6 +189,7 @@ export default memo(shapeComponent(class HayaSelect extends ShapeComponent {
         currentContent: PropTypes.func,
         disabled: PropTypes.bool,
         html: PropTypes.string,
+        right: PropTypes.node,
         text: PropTypes.node,
         value: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired
       })),
@@ -1361,6 +1363,7 @@ export default memo(shapeComponent(class HayaSelect extends ShapeComponent {
     const toggleOption = toggleOptions?.find((toggleOptionI) => toggleOptionI.value == toggleValue)
     const selected = this.getCurrentOptionValues().some((value) => value == option.value)
     let style
+    let contentNode
 
     if (mode == "current") {
       style = this.stylingFor("currentOptionPresentationText", {flex: 1, whiteSpace: "nowrap"})
@@ -1376,7 +1379,7 @@ export default memo(shapeComponent(class HayaSelect extends ShapeComponent {
           toggleValue: toggleOption?.value,
           value: option.value
         }, [option.text, option.value, toggleOption?.icon, toggleOption?.value])}
-        style={this.cache("optionPresentationStyle", {flexDirection: "row"})}
+        style={this.cache("optionPresentationStyle", {flexDirection: "row", alignItems: "center"})}
         testID="option-presentation"
       >
         {toggleOptions && !(option.value in toggled) &&
@@ -1395,17 +1398,17 @@ export default memo(shapeComponent(class HayaSelect extends ShapeComponent {
         }
         {(() => {
           if (optionContent) {
-            return optionContent({icon, mode, option, selected, toggleOption, toggleValue, toggled})
+            contentNode = optionContent({icon, mode, option, selected, toggleOption, toggleValue, toggled})
           } else if (mode == "current" && option.currentContent) {
-            return option.currentContent()
+            contentNode = option.currentContent()
           } else if (option.content) {
-            return option.content()
+            contentNode = option.content()
           } else if ("html" in option && Platform.OS != "web") {
-            return <RenderHtml source={{html: digg(option, "html")}} />
+            contentNode = <RenderHtml source={{html: digg(option, "html")}} />
           } else if ("html" in option && Platform.OS == "web") {
-            return <div dangerouslySetInnerHTML={{__html: digg(option, "html")}} />
+            contentNode = <div dangerouslySetInnerHTML={{__html: digg(option, "html")}} />
           } else {
-            return (
+            contentNode = (
               <Text
                 style={style}
                 testID="option-presentation-text"
@@ -1414,6 +1417,19 @@ export default memo(shapeComponent(class HayaSelect extends ShapeComponent {
               </Text>
             )
           }
+
+          return (
+            <>
+              <View style={this.cache("optionPresentationContentStyle", {flex: 1})}>
+                {contentNode}
+              </View>
+              {option.right &&
+                <View style={this.cache("optionPresentationRightStyle", {alignItems: "center", justifyContent: "center", marginLeft: 8})}>
+                  {option.right}
+                </View>
+              }
+            </>
+          )
         })()}
       </View>
     )

--- a/src/system-test-helpers.js
+++ b/src/system-test-helpers.js
@@ -1,0 +1,111 @@
+import waitFor from "awaitery/build/wait-for.js"
+
+/** @typedef {{systemTest: object, testId: string}} HayaSelectSystemTestHelperOptions */
+
+/**
+ * System test helper for interacting with HayaSelect instances.
+ */
+export default class HayaSelectSystemTestHelper {
+  /** @param {HayaSelectSystemTestHelperOptions} options */
+  constructor(options) {
+    if (!options) {
+      throw new Error(`Expected options for HayaSelectSystemTestHelper, got: ${options}`)
+    }
+
+    const {systemTest, testId, ...restArgs} = options
+    const extraKeys = Object.keys(restArgs)
+
+    if (extraKeys.length > 0) {
+      throw new Error(`Unexpected options for HayaSelectSystemTestHelper: ${extraKeys.join(", ")}`)
+    }
+
+    this.systemTest = systemTest
+    this.testId = testId
+    this.rootSelector = `[data-testid='${testId}']`
+    this.selectContainerSelector = `${this.rootSelector} [data-class='select-container']`
+    this.searchInputSelector = `${this.rootSelector} [data-class='search-text-input']`
+  }
+
+  /** @returns {Promise<void>} */
+  async open() {
+    await this.systemTest.click(this.selectContainerSelector)
+    await this.systemTest.find(this.searchInputSelector)
+  }
+
+  /** @returns {Promise<void>} */
+  async close() {
+    await this.systemTest.click(this.selectContainerSelector)
+    await waitFor({timeout: 5000}, async () => {
+      const searchInputs = await this.systemTest.all(this.searchInputSelector, {timeout: 0, visible: false})
+
+      if (searchInputs.length > 0) {
+        throw new Error("Search input is still visible")
+      }
+    })
+  }
+
+  /** @returns {Promise<boolean>} */
+  async isOpen() {
+    const scoundrel = await this.systemTest.getScoundrelClient()
+
+    return await scoundrel.evalResult(`
+      return Boolean(document.querySelector(${JSON.stringify(this.searchInputSelector)}))
+    `)
+  }
+
+  /** @returns {Promise<string[]>} */
+  async optionTexts() {
+    const options = await this.systemTest.all("[data-class='select-option']", {useBaseSelector: false})
+
+    return await Promise.all(options.map(async (option) => (await option.getText()).trim()))
+  }
+
+  /**
+   * @param {{index?: number, text?: string, value?: string|number}} criteria
+   * @returns {Promise<void>}
+   */
+  async selectOption({index, text, value, ...restArgs} = {}) {
+    if (arguments.length === 0) {
+      throw new Error("Expected criteria for selectOption, got: undefined")
+    }
+
+    const extraKeys = Object.keys(restArgs)
+
+    if (extraKeys.length > 0) {
+      throw new Error(`Unexpected selectOption criteria: ${extraKeys.join(", ")}`)
+    }
+
+    if (typeof value != "undefined") {
+      const option = await this.systemTest.find(`[data-class='select-option'][data-value='${value}']`, {useBaseSelector: false})
+      await this.systemTest.click(option)
+      return
+    }
+
+    if (typeof index == "number") {
+      const options = await this.systemTest.all("[data-class='select-option']", {useBaseSelector: false})
+      const option = options[index]
+
+      if (!option) throw new Error(`No option at index: ${index}`)
+
+      await this.systemTest.click(option)
+      return
+    }
+
+    if (text) {
+      const options = await this.systemTest.all("[data-class='select-option']", {useBaseSelector: false})
+
+      for (const option of options) {
+        const optionText = (await option.getText()).trim()
+
+        if (optionText === text) {
+          await this.systemTest.click(option)
+          return
+        }
+      }
+
+      throw new Error(`No option found with text: ${text}`)
+    }
+
+    throw new Error("Expected value, text, or index when selecting an option")
+  }
+}


### PR DESCRIPTION
## Summary
- add optionContent support and demo usage in the example app
- add optionContent system spec and split pagination specs into their own file
- add reusable HayaSelect system test helper and use it across specs
- guard system test start/stop across spec files to avoid duplicate servers

## Testing
- npx eslint src/select/index.jsx
- npx eslint example/App.tsx spec/system/haya-select-render-spec.js
- npx eslint spec/system/haya-select-render-spec.js spec/system/haya-select-pagination-spec.js
- npx eslint spec/system/haya-select-render-spec.js spec/system/haya-select-pagination-spec.js src/system-test-helpers.js
- npm run lint
- npm run typecheck
- npm run test:dist