### PR TITLE
Guard null controlled values in selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,3 +39,4 @@
 - Stabilize pagination manual entry system spec input handling.
 - Scroll pagination controls into view before scoundrel click dispatches.
 - Dispatch enter key events when setting pagination input value in system specs.
+- Guard current option value lookup when controlled values are null/undefined to avoid option rendering crashes.

--- a/src/select/index.jsx
+++ b/src/select/index.jsx
@@ -399,10 +399,16 @@ export default memo(shapeComponent(class HayaSelect extends ShapeComponent {
 
   getCurrentOptionValues() {
     if ("values" in this.props) {
-      return this.p.values
+      return Array.isArray(this.p.values) ? this.p.values : []
     }
 
-    return this.getCurrentOptions().map((option) => option.value)
+    const currentOptions = this.getCurrentOptions()
+
+    if (!currentOptions) return []
+
+    return currentOptions
+      .map((option) => option?.value)
+      .filter((value) => typeof value != "undefined")
   }
 
   componentDidMount() {


### PR DESCRIPTION
## Summary
- handle null/undefined controlled values in option selection
- avoid crashing while rendering options
- document the change in CHANGELOG

## Testing
- npm run lint (warns in src/system-test-helpers.js:99)
- npm run typecheck