### PR TITLE
Clear selected options when values are emptied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,3 +41,4 @@
 - Dispatch enter key events when setting pagination input value in system specs.
 - Guard current option value lookup when controlled values are null/undefined to avoid option rendering crashes.
 - Stabilize system test option selection by resetting cached option selectors on open and waiting for options.
+- Deselect multi-select options after highlight spec to avoid leaking state across system tests.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,3 +40,4 @@
 - Scroll pagination controls into view before scoundrel click dispatches.
 - Dispatch enter key events when setting pagination input value in system specs.
 - Guard current option value lookup when controlled values are null/undefined to avoid option rendering crashes.
+- Stabilize system test option selection by resetting cached option selectors on open and waiting for options.

--- a/spec/system/haya-select-render-spec.js
+++ b/spec/system/haya-select-render-spec.js
@@ -143,6 +143,9 @@ describe("HayaSelect", () => {
           expect(colors.allowed.includes(color)).toBe(true)
         })
 
+        await helper.selectOption({value: "one"})
+        await helper.selectOption({value: "two"})
+
         await helper.close()
       })
     })

--- a/spec/system/haya-select-render-spec.js
+++ b/spec/system/haya-select-render-spec.js
@@ -148,6 +148,60 @@ describe("HayaSelect", () => {
     })
   })
 
+  it("clears selected options after deselecting all values", async () => {
+    await timeout({timeout: 90000}, async () => {
+      await SystemTest.run(systemTestArgs, async (systemTest) => {
+        const helper = new HayaSelectSystemTestHelper({systemTest, testId: "hayaSelectMultipleRoot"})
+
+        await systemTest.findByTestID("hayaSelectMultipleRoot", {timeout: 60000})
+
+        const scoundrel = await systemTest.getScoundrelClient()
+        const currentSelectedText = async () => await scoundrel.evalResult(`
+          const element = document.querySelector("[data-testid='hayaSelectMultipleRoot'] [data-class='current-selected']")
+          return element ? element.textContent.trim() : ""
+        `)
+
+        const currentOptionCount = async () => await scoundrel.evalResult(`
+          const options = document.querySelectorAll("[data-testid='hayaSelectMultipleRoot'] [data-class='current-option']")
+          return options.length
+        `)
+
+        if (await helper.isOpen()) {
+          await helper.close()
+        }
+
+        await helper.open()
+        await helper.selectOption({value: "one"})
+        await helper.close()
+
+        await waitFor({timeout: 5000}, async () => {
+          const text = await currentSelectedText()
+
+          if (!text.includes("One")) {
+            throw new Error(`Expected selected label, got: ${text}`)
+          }
+        })
+
+        await helper.open()
+        await helper.selectOption({value: "one"})
+        await helper.close()
+
+        await waitFor({timeout: 5000}, async () => {
+          const count = await currentOptionCount()
+          const text = await currentSelectedText()
+
+          if (count !== 0) {
+            throw new Error(`Expected 0 current options, got: ${count}`)
+          }
+
+          if (!text.includes("Pick multiple")) {
+            throw new Error(`Expected placeholder, got: ${text}`)
+          }
+        })
+      })
+    })
+  })
+
   it("keeps rounded corners after opening and closing", async () => {
     await timeout({timeout: 90000}, async () => {
       await SystemTest.run(systemTestArgs, async (systemTest) => {

--- a/src/system-test-helpers.js
+++ b/src/system-test-helpers.js
@@ -31,6 +31,7 @@ export default class HayaSelectSystemTestHelper {
   async open() {
     await this.systemTest.click(this.selectContainerSelector)
     await this.systemTest.find(this.searchInputSelector)
+    this._optionsContainerSelector = null
   }
 
   /** @returns {Promise<void>} */
@@ -95,40 +96,48 @@ export default class HayaSelectSystemTestHelper {
     }
 
     if (typeof value != "undefined") {
-      const optionsContainerSelector = await this.optionsContainerSelector()
-      const option = await this.systemTest.find(
-        `${optionsContainerSelector} [data-class='select-option'][data-value='${value}']`,
-        {useBaseSelector: false}
-      )
-      await this.systemTest.click(option)
+      await waitFor({timeout: 5000}, async () => {
+        const optionsContainerSelector = await this.optionsContainerSelector()
+        const option = await this.systemTest.find(
+          `${optionsContainerSelector} [data-class='select-option'][data-value='${value}']`,
+          {useBaseSelector: false}
+        )
+
+        await this.systemTest.click(option)
+      })
       return
     }
 
     if (typeof index == "number") {
-      const optionsContainerSelector = await this.optionsContainerSelector()
-      const options = await this.systemTest.all(`${optionsContainerSelector} [data-class='select-option']`, {useBaseSelector: false})
-      const option = options[index]
+      await waitFor({timeout: 5000}, async () => {
+        const optionsContainerSelector = await this.optionsContainerSelector()
+        const options = await this.systemTest.all(`${optionsContainerSelector} [data-class='select-option']`, {useBaseSelector: false})
+        const option = options[index]
 
-      if (!option) throw new Error(`No option at index: ${index}`)
+        if (!option) throw new Error(`No option at index: ${index}`)
 
-      await this.systemTest.click(option)
+        await this.systemTest.click(option)
+      })
       return
     }
 
     if (text) {
-      const optionsContainerSelector = await this.optionsContainerSelector()
-      const options = await this.systemTest.all(`${optionsContainerSelector} [data-class='select-option']`, {useBaseSelector: false})
+      await waitFor({timeout: 5000}, async () => {
+        const optionsContainerSelector = await this.optionsContainerSelector()
+        const options = await this.systemTest.all(`${optionsContainerSelector} [data-class='select-option']`, {useBaseSelector: false})
 
-      for (const option of options) {
-        const optionText = (await option.getText()).trim()
+        for (const option of options) {
+          const optionText = (await option.getText()).trim()
 
-        if (optionText === text) {
-          await this.systemTest.click(option)
-          return
+          if (optionText === text) {
+            await this.systemTest.click(option)
+            return
+          }
         }
-      }
 
-      throw new Error(`No option found with text: ${text}`)
+        throw new Error(`No option found with text: ${text}`)
+      })
+      return
     }
 
     throw new Error("Expected value, text, or index when selecting an option")


### PR DESCRIPTION
## Summary
- clear current options when controlled values array is empty
- avoid stale selections when values are cleared
- add system test to cover deselect-all behavior

## Testing
- not run (system tests require `npm run test:dist`)