### PR TITLE
Fix HayaSelect close behavior after onChange

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -2,7 +2,7 @@ import Text from "@kaspernj/api-maker/build/utils/text"
 import {PortalHost,PortalProvider} from "conjointment"
 import {useEvent} from "expo"
 import OutsideEyeProvider from "outside-eye/build/provider.js"
-import React,{useEffect} from "react"
+import React,{useEffect,useState} from "react"
 import {Button,Platform,SafeAreaView,ScrollView,View} from "react-native"
 import SystemTestBrowserHelper from "system-testing/build/system-test-browser-helper.js"
 
@@ -24,6 +24,12 @@ export default function App() {
   }))
   const paginationPageSize = 5
   const paginationTotalCount = 24
+  const [actionTypeValue, setActionTypeValue] = useState<string | null>(null)
+  const actionTypeOptions = [
+    {value: "email", text: "Email"},
+    {value: "points", text: "Points"},
+    {value: "sms", text: "SMS"}
+  ]
 
   useEffect(() => {
     if (Platform.OS !== "web" || typeof window === "undefined") return;
@@ -123,6 +129,20 @@ export default function App() {
                     options={selectOptions}
                     placeholder="Pick multiple"
                   />
+                </View>
+              </Group>
+              <Group name="Close On Change Select">
+                <View testID="hayaSelectCloseOnChangeRoot">
+                  <HayaSelect
+                    onChangeValue={(value) => setActionTypeValue(value)}
+                    options={actionTypeOptions}
+                    placeholder="Pick action"
+                  />
+                  {actionTypeValue === "points" &&
+                    <Text testID="hayaSelectCloseOnChangeDetails">
+                      Points selected
+                    </Text>
+                  }
                 </View>
               </Group>
               <Group name="Paginated Select">

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -2,7 +2,7 @@ import Text from "@kaspernj/api-maker/build/utils/text"
 import {PortalHost,PortalProvider} from "conjointment"
 import {useEvent} from "expo"
 import OutsideEyeProvider from "outside-eye/build/provider.js"
-import React,{useEffect,useState} from "react"
+import React, {useEffect, useState} from "react"
 import {Button,Platform,SafeAreaView,ScrollView,View} from "react-native"
 import SystemTestBrowserHelper from "system-testing/build/system-test-browser-helper.js"
 

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -25,7 +25,8 @@
         "react-native-render-html": "^6.3.4",
         "react-native-vector-icons": "^10.2.0",
         "react-native-web": "~0.19.13",
-        "set-state-compare": "^1.0.64"
+        "set-state-compare": "^1.0.64",
+        "ya-use-event-listener": "^0.1.1"
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",
@@ -34,7 +35,7 @@
       }
     },
     "..": {
-      "version": "1.0.89",
+      "version": "1.0.94",
       "license": "MIT",
       "dependencies": {
         "classnames": "^2.3.1",
@@ -51,7 +52,7 @@
         "expo-module-scripts": "^4.0.2",
         "react": "18.3.1",
         "react-native": "0.76.9",
-        "scoundrel-remote-eval": "1.0.27",
+        "scoundrel-remote-eval": "1.0.31",
         "sqlite": "^5.1.1",
         "sqlite3": "^5.1.7",
         "system-testing": "^1.0.62",
@@ -123,7 +124,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.0.tgz",
       "integrity": "sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.0",
@@ -518,6 +518,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.25.9.tgz",
       "integrity": "sha512-ZkRyVkThtxQ/J6nv3JFYv1RYY+JT5BvU0y3k5bWrmuG4woXypRa4PXmm9RhOwodRkYFWqC0C0cqcJ4OqR7kW+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9",
         "@babel/traverse": "^7.25.9"
@@ -534,6 +535,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-class-field-initializer-scope/-/plugin-bugfix-safari-class-field-initializer-scope-7.25.9.tgz",
       "integrity": "sha512-MrGRLZxLD/Zjj0gdU15dfs+HH/OXvnw/U4jJD8vpcP2CJQapPEv1IWwjc/qMg7ItBlPwSv1hRBbb7LeuANdcnw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -549,6 +551,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.25.9.tgz",
       "integrity": "sha512-2qUwwfAFpJLZqxd02YW9btUCZHl+RFvdDkNfZwaIJrvB8Tesjsk8pEQkTvGwZXLqXUx/2oyY3ySRhm6HOXuCug==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -564,6 +567,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.25.9.tgz",
       "integrity": "sha512-6xWgLZTJXwilVjlnV7ospI3xi+sl8lN8rXXbBD6vYn3UYDlGsag8wrZkKcSI8G6KgqKP7vNFaDgeDnfAABq61g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9",
@@ -581,6 +585,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.25.9.tgz",
       "integrity": "sha512-aLnMXYPnzwwqhYSCyXfKkIkYgJ8zv9RK+roo9DkTXz38ynIhd9XCbN08s3MGvqL2MYGVUGdRQLL/JqBIeJhJBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9",
         "@babel/traverse": "^7.25.9"
@@ -681,6 +686,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
       "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       },
@@ -801,6 +807,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.26.0.tgz",
       "integrity": "sha512-QCWT5Hh830hK5EQa7XzuqIkQU9tT/whqbDz7kuaZMHFl1inRRg7JnuAEOQ0Ur0QUl0NufCk1msK2BeY79Aj/eg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -987,6 +994,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-unicode-sets-regex/-/plugin-syntax-unicode-sets-regex-7.18.6.tgz",
       "integrity": "sha512-727YkEAPwSIQTv5im8QHz3upqp92JTWhidIC81Tdx4VJYIte/VndKf1qKrfnnhPLiPghStWfvC/iFaMCQu7Nqg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.18.6",
         "@babel/helper-plugin-utils": "^7.18.6"
@@ -1052,6 +1060,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.25.9.tgz",
       "integrity": "sha512-toHc9fzab0ZfenFpsyYinOX0J/5dgJVA2fm64xPewu7CoYHWEivIWKxkK2rMi4r3yQqLnVmheMXRdG+k239CgA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1098,6 +1107,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.26.0.tgz",
       "integrity": "sha512-6J2APTs7BDDm+UMqP1useWqhcRAXo0WIoVj26N7kPFB6S73Lgvyka4KTZYIxtgYXiN5HTyRObA72N2iu628iTQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-create-class-features-plugin": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9"
@@ -1165,6 +1175,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.25.9.tgz",
       "integrity": "sha512-t7ZQ7g5trIgSRYhI9pIJtRl64KHotutUJsh4Eze5l7olJv+mRSg4/MmbZ0tv1eeqRbdvo/+trvJD/Oc5DmW2cA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9"
@@ -1181,6 +1192,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.25.9.tgz",
       "integrity": "sha512-LZxhJ6dvBb/f3x8xwWIuyiAHy56nrRG3PeYTpBkkzkYRRQ6tJLu68lEF5VIqMUZiAV7a8+Tb78nEoMCMcqjXBw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1196,6 +1208,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.25.9.tgz",
       "integrity": "sha512-0UfuJS0EsXbRvKnwcLjFtJy/Sxc5J5jhLHnFhy7u4zih97Hz6tJkLU+O+FMMrNZrosUPxDi6sYxJ/EA8jDiAog==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9"
@@ -1212,6 +1225,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.25.9.tgz",
       "integrity": "sha512-GCggjexbmSLaFhqsojeugBpeaRIgWNTcgKVq/0qIteFEqY2A+b9QidYadrWlnbWQUrW5fn+mCvf3tr7OeBFTyg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1227,6 +1241,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.26.3.tgz",
       "integrity": "sha512-7CAHcQ58z2chuXPWblnn1K6rLDnDWieghSOEmqQsrBenH0P9InCUtOJYD89pvngljmZlJcz3fcmgYsXFNGa1ZQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1306,6 +1321,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.25.9.tgz",
       "integrity": "sha512-xoTMk0WXceiiIvsaquQQUaLLXSW1KJ159KP87VilruQm0LNNGxWzahxSS6T6i4Zg3ezp4vA4zuwiNUR53qmQAw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1351,6 +1367,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.25.9.tgz",
       "integrity": "sha512-PYazBVfofCQkkMzh2P6IdIUaCEWni3iYEerAsRWuVd8+jlM1S9S9cz1dF9hIzyoZ8IA3+OwVYIp9v9e+GbgZhA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1366,6 +1383,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.25.9.tgz",
       "integrity": "sha512-g5T11tnI36jVClQlMlt4qKDLlWnG5pP9CSM4GhdRciTNMRgkfpo5cR6b4rGIOYPgRRuFAvwjPQ/Yk+ql4dyhbw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-module-transforms": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9"
@@ -1398,6 +1416,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.25.9.tgz",
       "integrity": "sha512-hyss7iIlH/zLHaehT+xwiymtPOpsiwIIRlCAOwBB04ta5Tt+lNItADdlXw3jAWZ96VJ2jlhl/c+PNIQPKNfvcA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-module-transforms": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9",
@@ -1416,6 +1435,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.25.9.tgz",
       "integrity": "sha512-bS9MVObUgE7ww36HEfwe6g9WakQ0KF07mQF74uuXdkoziUPfKyu/nIm663kz//e5O1nPInPFx36z7WJmJ4yNEw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-module-transforms": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9"
@@ -1448,6 +1468,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.25.9.tgz",
       "integrity": "sha512-U/3p8X1yCSoKyUj2eOBIx3FOn6pElFOKvAAGf8HTtItuPyB+ZeOqfn+mvTtg9ZlOAjsPdK3ayQEjqHjU/yLeVQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1510,6 +1531,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.25.9.tgz",
       "integrity": "sha512-Kj/Gh+Rw2RNLbCK1VAWj2U48yxxqL2x0k10nPtSdRa0O2xnHXalD0s+o1A6a0W43gJ00ANo38jxkQreckOzv5A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9",
         "@babel/helper-replace-supers": "^7.25.9"
@@ -1605,6 +1627,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.25.9.tgz",
       "integrity": "sha512-IvIUeV5KrS/VPavfSM/Iu+RE6llrHrYIKY1yfCzyO/lMXHQ+p7uGhonmGVisv6tSBSVgWzMBohTcvkC9vQcQFA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1731,6 +1754,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-7.26.0.tgz",
       "integrity": "sha512-vN6saax7lrA2yA/Pak3sCxuD6F5InBjn9IcrIKQPjpsLvuHYLVroTxjdlVRHjjBWxKOqIwpTXDkOssYT4BFdRw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9"
@@ -1747,6 +1771,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.25.9.tgz",
       "integrity": "sha512-7DL7DKYjn5Su++4RXu8puKZm2XBPHyjWLUidaPEkCUBbE7IPcsrkRHggAOOKydH1dASWdcUBxrkOGNxUv5P3Jg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1828,6 +1853,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.25.9.tgz",
       "integrity": "sha512-o97AE4syN71M/lxrCtQByzphAdlYluKPDBzDVzMmfCobUjjhAryZV0AIpRPrxN0eAkxXO6ZLEScmt+PNhj2OTw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1843,6 +1869,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.25.9.tgz",
       "integrity": "sha512-v61XqUMiueJROUv66BVIOi0Fv/CUuZuZMl5NkRoCVxLAnMexZ0A3kMe7vvZ0nulxMuMp0Mk6S5hNh48yki08ZA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1877,6 +1904,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.25.9.tgz",
       "integrity": "sha512-s5EDrE6bW97LtxOcGj1Khcx5AaXwiMmi4toFWRDP9/y0Woo6pXC+iyPu/KuhKtfSrNFd7jJB+/fkOtZy6aIC6Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1892,6 +1920,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.25.9.tgz",
       "integrity": "sha512-Jt2d8Ga+QwRluxRQ307Vlxa6dMrYEMZCgGxoPR8V52rxPyldHu3hdlHspxaqYmE7oID5+kB+UKUB/eWS+DkkWg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9"
@@ -1924,6 +1953,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.25.9.tgz",
       "integrity": "sha512-8BYqO3GeVNHtx69fdPshN3fnzUNLrWdHhk/icSwigksJGczKSizZ+Z6SBCxTs723Fr5VSNorTIK7a+R2tISvwQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9"
@@ -2041,6 +2071,7 @@
       "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.6-no-external-plugins.tgz",
       "integrity": "sha512-HrcgcIESLm9aIR842yhJ5RWan/gebQUJ6E/E5+rf0y9o6oj7w0Br+sWuL6kEQ/o/AdfvR1Je9jG18/gnpwjEyA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/types": "^7.4.4",
@@ -2619,7 +2650,6 @@
       "resolved": "https://registry.npmjs.org/@expo/metro-runtime/-/metro-runtime-4.0.1.tgz",
       "integrity": "sha512-CRpbLvdJ1T42S+lrYa1iZp1KfDeBp4oeZOK3hdpiS5n0vR0nhD6sC1gGF0sTboCTp64tLteikz5Y3j53dvgOIw==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "react-native": "*"
       }
@@ -3141,8 +3171,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@jsamr/counter-style/-/counter-style-2.0.2.tgz",
       "integrity": "sha512-2mXudGVtSzVxWEA7B9jZLKjoXUeUFYDDtFrQoC0IFX9/Dszz4t1vZOmafi3JSw/FxD+udMQ+4TAFR8Qs0J3URQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@jsamr/react-native-li": {
       "version": "2.3.1",
@@ -3160,7 +3189,6 @@
       "resolved": "https://registry.npmjs.org/@kaspernj/api-maker/-/api-maker-1.0.2062.tgz",
       "integrity": "sha512-Msdqg5CPp0mrsg2GrZlC3W7CL9HECtBCfuiOJpsPV+DmjyRtuzZl2/vyfLpmoVYAdb/XTxYSZks0cNCZ1v4zpw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "clone-deep": ">= 4.0.1",
         "debounce": ">= 2.0.0",
@@ -3820,7 +3848,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.18.tgz",
       "integrity": "sha512-t4yC+vtgnkYjNSKlFx1jkAhH8LgTo2N/7Qvi83kdEaUtMDiwpbLAktKDaAMlRcJ5eSxZkH74eEGt1ky31d7kfQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -3831,6 +3858,7 @@
       "resolved": "https://registry.npmjs.org/@types/react-native/-/react-native-0.72.8.tgz",
       "integrity": "sha512-St6xA7+EoHN5mEYfdWnfYt0e8u6k2FR0P9s2arYgakQGFgU1f9FlPrIEcj0X24pLCF5c5i3WVuLCUdiCYHmOoA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@react-native/virtualized-lists": "^0.72.4",
         "@types/react": "*"
@@ -3841,6 +3869,7 @@
       "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.72.8.tgz",
       "integrity": "sha512-J3Q4Bkuo99k7mu+jPS9gSUSgq+lLRSI/+ahXNwV92XgJ/8UgOTxu2LPwhJnBk/sQKxq7E8WkZBnBiozukQMqrw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "invariant": "^2.2.4",
         "nullthrows": "^1.1.1"
@@ -4440,7 +4469,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -5642,6 +5670,7 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5772,7 +5801,6 @@
       "resolved": "https://registry.npmjs.org/expo/-/expo-52.0.23.tgz",
       "integrity": "sha512-DR36Vkpz/ZLPci4fxDBG/pLk26nGK63vcZ+X4RZJfNBzi14DXZ939loP8YzWGV78Qp23qdPINczpo2727tqLxg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.20.0",
         "@expo/cli": "0.22.7",
@@ -9371,7 +9399,6 @@
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -9383,7 +9410,6 @@
       "resolved": "https://registry.npmjs.org/prop-types-exact/-/prop-types-exact-1.2.7.tgz",
       "integrity": "sha512-A4RaV6mg3jocQqBYmqi2ojJ2VnV4AKTEHhl3xHsud08/u87gcVJc8DUOtgnPegoOCQv/shUqEk4eZGYibjnHzQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.3",
         "es-errors": "^1.3.0",
@@ -9523,7 +9549,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -9595,7 +9620,6 @@
       "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.76.5.tgz",
       "integrity": "sha512-op2p2kB+lqMF1D7AdX4+wvaR0OPFbvWYs+VBE7bwsb99Cn9xISrLRLAgFflZedQsa5HvnOGrULhtnmItbIKVVw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/create-cache-key-function": "^29.6.3",
         "@react-native/assets-registry": "0.76.5",
@@ -9679,7 +9703,6 @@
       "integrity": "sha512-IFQ0RE57819hOUdFvgK4FowM5aMXg7C7XKsuGLevqXkkIJatc3QopN0wYrb2IrzUgmdpfP+QVIbI3S6h7M0btw==",
       "deprecated": "react-native-vector-icons package has moved to a new model of per-icon-family packages. See the https://github.com/oblador/react-native-vector-icons/blob/master/MIGRATION.md on how to migrate",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prop-types": "^15.7.2",
         "yargs": "^16.1.1"
@@ -12024,6 +12047,18 @@
       "license": "ISC",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/ya-use-event-listener": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ya-use-event-listener/-/ya-use-event-listener-0.1.1.tgz",
+      "integrity": "sha512-zLuYK3XsYFGBME4OkffOO/bmX7/eTl+01OEA6RLzidfxWeuJtEagXHdDYhMu2EcZyhbc2Dq5LUB8jgKKfZ4suA==",
+      "license": "MIT",
+      "dependencies": {
+        "env-sense": ">= 1.0.2"
+      },
+      "peerDependencies": {
+        "react": ">=18.3.0"
       }
     },
     "node_modules/yallist": {

--- a/example/package.json
+++ b/example/package.json
@@ -26,7 +26,8 @@
     "react-native-render-html": "^6.3.4",
     "react-native-vector-icons": "^10.2.0",
     "react-native-web": "~0.19.13",
-    "set-state-compare": "^1.0.64"
+    "set-state-compare": "^1.0.64",
+    "ya-use-event-listener": "^0.1.1"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "haya-select",
-  "version": "1.0.94",
+  "version": "1.0.95",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "haya-select",
-      "version": "1.0.94",
+      "version": "1.0.95",
       "license": "MIT",
       "dependencies": {
         "classnames": "^2.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haya-select",
-  "version": "1.0.94",
+  "version": "1.0.95",
   "description": "Just another select component for React Native + Web.",
   "files": [
     "build/**"
@@ -15,11 +15,10 @@
     "test": "node scripts/velocious-test.js",
     "test:dist": "npm run build:example:dist && SYSTEM_TEST_HOST=dist npm test",
     "prepare": "expo-module prepare",
-    "release:patch": "npm version patch && npm publish",
+    "release:patch": "npm version patch -m \"Bump version to %s\" && git push --follow-tags && npm whoami || npm login && npm publish",
     "prepublishOnly": "expo-module prepublishOnly",
     "open:ios": "xed example/ios",
     "open:android": "open -a \"Android Studio\" example/android",
-    "release:patch": "npm version patch -m \"Bump version to %s\" && git push --follow-tags && npm whoami || npm login && npm publish",
     "typecheck": "tsc --noEmit"
   },
   "keywords": [

--- a/spec/system/haya-select-pagination-spec.js
+++ b/spec/system/haya-select-pagination-spec.js
@@ -121,8 +121,15 @@ const paginationLabelText = async (systemTest) => {
 }
 
 const waitForPaginationLabel = async (systemTest, expectedText) => {
+  const expectedPage = Number(expectedText.match(/Page (\\d+) of/)?.[1])
   await waitFor({timeout: 5000}, async () => {
     const labelText = await paginationLabelText(systemTest)
+
+    if (labelText === expectedText) return
+
+    if (Number.isFinite(expectedPage) && labelText === String(expectedPage)) return
+
+    if (!Number.isFinite(expectedPage) && labelText === expectedText) return
 
     if (labelText !== expectedText) {
       throw new Error(`Unexpected pagination label: ${labelText}`)

--- a/spec/system/haya-select-pagination-spec.js
+++ b/spec/system/haya-select-pagination-spec.js
@@ -69,14 +69,12 @@ const openPaginatedSelect = async (systemTest) => {
 }
 
 const closePaginatedSelect = async (systemTest) => {
-  const scoundrel = await systemTest.getScoundrelClient()
-  const isOpen = await scoundrel.evalResult(`
-    (() => {
-      return Boolean(document.querySelector("[data-testid='hayaSelectPaginationRoot'] [data-class='search-text-input']"))
-    })()
-  `)
+  const inputs = await systemTest.all(
+    "[data-testid='hayaSelectPaginationRoot'] [data-class='search-text-input']",
+    {timeout: 0, visible: false}
+  )
 
-  if (isOpen) {
+  if (inputs.length > 0) {
     await systemTest.click("[data-testid='hayaSelectPaginationRoot'] [data-class='select-container']")
   }
 }

--- a/spec/system/haya-select-pagination-spec.js
+++ b/spec/system/haya-select-pagination-spec.js
@@ -31,7 +31,9 @@ afterAll(async () => {
 const openPaginatedSelect = async (systemTest) => {
   const scoundrel = await systemTest.getScoundrelClient()
   const isOpen = await scoundrel.evalResult(`
-    return Boolean(document.querySelector("[data-testid='hayaSelectPaginationRoot'] [data-class='search-text-input']"))
+    (() => {
+      return Boolean(document.querySelector("[data-testid='hayaSelectPaginationRoot'] [data-class='search-text-input']"))
+    })()
   `)
 
   if (!isOpen) {
@@ -41,7 +43,9 @@ const openPaginatedSelect = async (systemTest) => {
 
   await waitFor({timeout: 5000}, async () => {
     const paginationVisible = await scoundrel.evalResult(`
-      return Boolean(document.querySelector("[data-class='options-pagination']"))
+      (() => {
+        return Boolean(document.querySelector("[data-class='options-pagination']"))
+      })()
     `)
 
     if (!paginationVisible) {
@@ -50,8 +54,10 @@ const openPaginatedSelect = async (systemTest) => {
   })
 
   const labelText = await scoundrel.evalResult(`
-    const label = document.querySelector("[data-class='pagination-label']")
-    return label ? label.textContent.trim() : null
+    (() => {
+      const label = document.querySelector("[data-class='pagination-label']")
+      return label ? label.textContent.trim() : null
+    })()
   `)
 
   if (labelText && !labelText.startsWith("Page 1 of ")) {
@@ -65,7 +71,9 @@ const openPaginatedSelect = async (systemTest) => {
 const closePaginatedSelect = async (systemTest) => {
   const scoundrel = await systemTest.getScoundrelClient()
   const isOpen = await scoundrel.evalResult(`
-    return Boolean(document.querySelector("[data-testid='hayaSelectPaginationRoot'] [data-class='search-text-input']"))
+    (() => {
+      return Boolean(document.querySelector("[data-testid='hayaSelectPaginationRoot'] [data-class='search-text-input']"))
+    })()
   `)
 
   if (isOpen) {
@@ -77,8 +85,10 @@ const paginationLabelText = async (systemTest) => {
   const scoundrel = await systemTest.getScoundrelClient()
 
   return await scoundrel.evalResult(`
-    const element = document.querySelector("[data-class='pagination-label']")
-    return element ? element.textContent.trim() : null
+    (() => {
+      const element = document.querySelector("[data-class='pagination-label']")
+      return element ? element.textContent.trim() : null
+    })()
   `)
 }
 
@@ -118,11 +128,13 @@ const clickPaginationSelector = async (systemTest, selector) => {
 
   await waitFor({timeout: 5000}, async () => {
     const clicked = await scoundrel.evalResult(`
-      const element = document.querySelector(${JSON.stringify(selector)})
-      if (!element) return false
-      element.scrollIntoView?.({block: "center", inline: "center"})
-      element.dispatchEvent(new MouseEvent("click", {bubbles: true, cancelable: true}))
-      return true
+      (() => {
+        const element = document.querySelector(${JSON.stringify(selector)})
+        if (!element) return false
+        element.scrollIntoView?.({block: "center", inline: "center"})
+        element.dispatchEvent(new MouseEvent("click", {bubbles: true, cancelable: true}))
+        return true
+      })()
     `)
 
     if (!clicked) {
@@ -136,21 +148,23 @@ const setPaginationInputValue = async (systemTest, value) => {
 
   await waitFor({timeout: 5000}, async () => {
     const updated = await scoundrel.evalResult(`
-      const element = document.querySelector("[data-class='pagination-input']")
-      if (!element) return false
-      const nativeSetter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")?.set
-      element.focus()
-      if (nativeSetter) {
-        nativeSetter.call(element, ${JSON.stringify(value)})
-      } else {
-        element.value = ${JSON.stringify(value)}
-      }
-      element.dispatchEvent(new Event("input", {bubbles: true}))
-      element.dispatchEvent(new Event("change", {bubbles: true}))
-      element.dispatchEvent(new KeyboardEvent("keydown", {key: "Enter", code: "Enter", keyCode: 13, which: 13, bubbles: true}))
-      element.dispatchEvent(new KeyboardEvent("keypress", {key: "Enter", code: "Enter", keyCode: 13, which: 13, bubbles: true}))
-      element.dispatchEvent(new KeyboardEvent("keyup", {key: "Enter", code: "Enter", keyCode: 13, which: 13, bubbles: true}))
-      return true
+      (() => {
+        const element = document.querySelector("[data-class='pagination-input']")
+        if (!element) return false
+        const nativeSetter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")?.set
+        element.focus()
+        if (nativeSetter) {
+          nativeSetter.call(element, ${JSON.stringify(value)})
+        } else {
+          element.value = ${JSON.stringify(value)}
+        }
+        element.dispatchEvent(new Event("input", {bubbles: true}))
+        element.dispatchEvent(new Event("change", {bubbles: true}))
+        element.dispatchEvent(new KeyboardEvent("keydown", {key: "Enter", code: "Enter", keyCode: 13, which: 13, bubbles: true}))
+        element.dispatchEvent(new KeyboardEvent("keypress", {key: "Enter", code: "Enter", keyCode: 13, which: 13, bubbles: true}))
+        element.dispatchEvent(new KeyboardEvent("keyup", {key: "Enter", code: "Enter", keyCode: 13, which: 13, bubbles: true}))
+        return true
+      })()
     `)
 
     if (!updated) {

--- a/spec/system/haya-select-pagination-spec.js
+++ b/spec/system/haya-select-pagination-spec.js
@@ -12,7 +12,7 @@ let didStartSystemTest = false
 beforeAll(async () => {
   const systemTest = SystemTest.current(systemTestArgs)
   if (!systemTest.isStarted()) {
-    await timeout({timeout: 60000}, async () => {
+    await timeout({timeout: 30000}, async () => {
       await systemTest.start()
     })
     didStartSystemTest = true
@@ -23,7 +23,7 @@ beforeAll(async () => {
 afterAll(async () => {
   if (!didStartSystemTest) return
 
-  await timeout({timeout: 60000}, async () => {
+  await timeout({timeout: 30000}, async () => {
     await SystemTest.current().stop()
   })
 })
@@ -33,7 +33,7 @@ const setPaginationInputValue = async (systemTest, value) => {
     const element = await systemTest.find("[data-class='pagination-input']", {useBaseSelector: false})
     const driver = systemTest.getDriver()
     await driver.executeScript(
-      "arguments[0].value = arguments[1]; arguments[0].dispatchEvent(new Event('input', {bubbles: true})); arguments[0].dispatchEvent(new Event('change', {bubbles: true})); arguments[0].blur();",
+      "arguments[0].focus(); arguments[0].value = arguments[1]; arguments[0].dispatchEvent(new Event('input', {bubbles: true})); arguments[0].dispatchEvent(new Event('change', {bubbles: true})); arguments[0].blur();",
       element,
       String(value)
     )
@@ -54,7 +54,7 @@ const openPaginatedSelect = async (systemTest) => {
       selectContainer
     )
     await systemTest.click(selectContainer)
-    await waitFor({timeout: 10000}, async () => {
+    await waitFor({timeout: 5000}, async () => {
       const searchInputsAfterClick = await systemTest.all(
         "[data-testid='hayaSelectPaginationRoot'] [data-class='search-text-input']",
         {timeout: 0, visible: true}
@@ -71,7 +71,7 @@ const openPaginatedSelect = async (systemTest) => {
     selectContainer
   )
   await systemTest.click(selectContainer)
-  await waitFor({timeout: 10000}, async () => {
+  await waitFor({timeout: 5000}, async () => {
     const searchInputsAfterClick = await systemTest.all(
       "[data-testid='hayaSelectPaginationRoot'] [data-class='search-text-input']",
       {timeout: 0, visible: true}
@@ -121,7 +121,7 @@ const paginationLabelText = async (systemTest) => {
 }
 
 const waitForPaginationLabel = async (systemTest, expectedText) => {
-  const expectedPage = Number(expectedText.match(/Page (\\d+) of/)?.[1])
+  const expectedPage = Number(expectedText.match(/Page (\d+) of/)?.[1])
   await waitFor({timeout: 5000}, async () => {
     const labelText = await paginationLabelText(systemTest)
 
@@ -174,7 +174,7 @@ const clickPaginationSelector = async (systemTest, selector) => {
 
 describe("HayaSelect pagination", () => {
   afterEach(async () => {
-    await timeout({timeout: 60000}, async () => {
+    await timeout({timeout: 30000}, async () => {
       await SystemTest.run(systemTestArgs, async (systemTest) => {
         await closePaginatedSelect(systemTest)
       })
@@ -186,7 +186,7 @@ describe("HayaSelect pagination", () => {
       await SystemTest.run(systemTestArgs, async (systemTest) => {
         const helper = new HayaSelectSystemTestHelper({systemTest, testId: "hayaSelectPaginationRoot"})
 
-        await systemTest.findByTestID("hayaSelectPaginationRoot", {timeout: 60000})
+        await systemTest.findByTestID("hayaSelectPaginationRoot", {timeout: 5000})
         await openPaginatedSelect(systemTest)
 
         const pageTwo = await findPaginationPageButton(systemTest, 2)
@@ -205,11 +205,11 @@ describe("HayaSelect pagination", () => {
   })
 
   it("accepts manual page entry from the pagination label", async () => {
-    await timeout({timeout: 60000}, async () => {
+    await timeout({timeout: 30000}, async () => {
       await SystemTest.run(systemTestArgs, async (systemTest) => {
         const helper = new HayaSelectSystemTestHelper({systemTest, testId: "hayaSelectPaginationRoot"})
 
-        await systemTest.findByTestID("hayaSelectPaginationRoot", {timeout: 60000})
+        await systemTest.findByTestID("hayaSelectPaginationRoot", {timeout: 5000})
         await openPaginatedSelect(systemTest)
 
         await setPaginationInputValue(systemTest, "4")
@@ -227,11 +227,11 @@ describe("HayaSelect pagination", () => {
   })
 
   it("supports next and previous pagination buttons", async () => {
-    await timeout({timeout: 60000}, async () => {
+    await timeout({timeout: 30000}, async () => {
       await SystemTest.run(systemTestArgs, async (systemTest) => {
         const helper = new HayaSelectSystemTestHelper({systemTest, testId: "hayaSelectPaginationRoot"})
 
-        await systemTest.findByTestID("hayaSelectPaginationRoot", {timeout: 60000})
+        await systemTest.findByTestID("hayaSelectPaginationRoot", {timeout: 5000})
         await openPaginatedSelect(systemTest)
         await waitForPaginationLabel(systemTest, "Page 1 of 5")
 

--- a/spec/system/haya-select-pagination-spec.js
+++ b/spec/system/haya-select-pagination-spec.js
@@ -31,11 +31,12 @@ afterAll(async () => {
 const setPaginationInputValue = async (systemTest, value) => {
   await waitFor({timeout: 5000}, async () => {
     const element = await systemTest.find("[data-class='pagination-input']", {useBaseSelector: false})
-    await systemTest.interact(element, "click")
-    await systemTest.interact(element, "sendKeys", "\uE009", "a")
-    await systemTest.interact(element, "sendKeys", "\uE003")
-    await systemTest.interact(element, "sendKeys", String(value))
-    await systemTest.interact(element, "sendKeys", "\uE007")
+    const driver = systemTest.getDriver()
+    await driver.executeScript(
+      "arguments[0].value = arguments[1]; arguments[0].dispatchEvent(new Event('input', {bubbles: true})); arguments[0].dispatchEvent(new Event('change', {bubbles: true})); arguments[0].blur();",
+      element,
+      String(value)
+    )
   })
 }
 

--- a/spec/system/haya-select-pagination-spec.js
+++ b/spec/system/haya-select-pagination-spec.js
@@ -12,7 +12,7 @@ let didStartSystemTest = false
 beforeAll(async () => {
   const systemTest = SystemTest.current(systemTestArgs)
   if (!systemTest.isStarted()) {
-    await timeout({timeout: 90000}, async () => {
+    await timeout({timeout: 60000}, async () => {
       await systemTest.start()
     })
     didStartSystemTest = true
@@ -23,71 +23,100 @@ beforeAll(async () => {
 afterAll(async () => {
   if (!didStartSystemTest) return
 
-  await timeout({timeout: 120000}, async () => {
+  await timeout({timeout: 60000}, async () => {
     await SystemTest.current().stop()
   })
 })
 
-const openPaginatedSelect = async (systemTest) => {
-  const scoundrel = await systemTest.getScoundrelClient()
-  const isOpen = await scoundrel.evalResult(`
-    (() => {
-      return Boolean(document.querySelector("[data-testid='hayaSelectPaginationRoot'] [data-class='search-text-input']"))
-    })()
-  `)
+const setPaginationInputValue = async (systemTest, value) => {
+  await waitFor({timeout: 5000}, async () => {
+    const element = await systemTest.find("[data-class='pagination-input']", {useBaseSelector: false})
+    await systemTest.interact(element, "click")
+    await systemTest.interact(element, "sendKeys", "\uE009", "a")
+    await systemTest.interact(element, "sendKeys", "\uE003")
+    await systemTest.interact(element, "sendKeys", String(value))
+    await systemTest.interact(element, "sendKeys", "\uE007")
+  })
+}
 
-  if (!isOpen) {
-    await systemTest.click("[data-testid='hayaSelectPaginationRoot'] [data-class='select-container']")
-    await systemTest.find("[data-testid='hayaSelectPaginationRoot'] [data-class='search-text-input']")
+const openPaginatedSelect = async (systemTest) => {
+  const selectContainer = await systemTest.find("[data-testid='hayaSelectPaginationRoot'] [data-class='select-container']")
+  const driver = systemTest.getDriver()
+  const searchInputs = await systemTest.all(
+    "[data-testid='hayaSelectPaginationRoot'] [data-class='search-text-input']",
+    {timeout: 0, visible: true}
+  )
+
+  if (searchInputs.length > 0) {
+    await driver.executeScript(
+      "arguments[0].scrollIntoView({block: 'center', inline: 'center'})",
+      selectContainer
+    )
+    await systemTest.click(selectContainer)
+    await waitFor({timeout: 10000}, async () => {
+      const searchInputsAfterClick = await systemTest.all(
+        "[data-testid='hayaSelectPaginationRoot'] [data-class='search-text-input']",
+        {timeout: 0, visible: true}
+      )
+
+      if (searchInputsAfterClick.length > 0) {
+        throw new Error("Search input still visible")
+      }
+    })
   }
 
-  await waitFor({timeout: 5000}, async () => {
-    const paginationVisible = await scoundrel.evalResult(`
-      (() => {
-        return Boolean(document.querySelector("[data-class='options-pagination']"))
-      })()
-    `)
+  await driver.executeScript(
+    "arguments[0].scrollIntoView({block: 'center', inline: 'center'})",
+    selectContainer
+  )
+  await systemTest.click(selectContainer)
+  await waitFor({timeout: 10000}, async () => {
+    const searchInputsAfterClick = await systemTest.all(
+      "[data-testid='hayaSelectPaginationRoot'] [data-class='search-text-input']",
+      {timeout: 0, visible: true}
+    )
 
-    if (!paginationVisible) {
+    if (searchInputsAfterClick.length === 0) {
+      throw new Error("Search input not visible yet")
+    }
+  })
+
+  await waitFor({timeout: 5000}, async () => {
+    const paginationElements = await systemTest.all("[data-class='options-pagination']", {timeout: 0, useBaseSelector: false})
+
+    if (paginationElements.length === 0) {
       throw new Error("Pagination not visible yet")
     }
   })
 
-  const labelText = await scoundrel.evalResult(`
-    (() => {
-      const label = document.querySelector("[data-class='pagination-label']")
-      return label ? label.textContent.trim() : null
-    })()
-  `)
-
-  if (labelText && !labelText.startsWith("Page 1 of ")) {
-    const pageOne = await findPaginationPageButton(systemTest, 1)
-    await systemTest.click(pageOne)
-  }
-
-  await waitForPaginationLabel(systemTest, "Page 1 of 5")
+  await paginationLabelText(systemTest)
 }
 
 const closePaginatedSelect = async (systemTest) => {
   const inputs = await systemTest.all(
     "[data-testid='hayaSelectPaginationRoot'] [data-class='search-text-input']",
-    {timeout: 0, visible: false}
+    {timeout: 0, visible: true}
   )
 
   if (inputs.length > 0) {
-    await systemTest.click("[data-testid='hayaSelectPaginationRoot'] [data-class='select-container']")
+    const selectContainer = await systemTest.find("[data-testid='hayaSelectPaginationRoot'] [data-class='select-container']")
+    const driver = systemTest.getDriver()
+    await driver.executeScript(
+      "arguments[0].scrollIntoView({block: 'center', inline: 'center'})",
+      selectContainer
+    )
+    await systemTest.click(selectContainer)
   }
 }
 
 const paginationLabelText = async (systemTest) => {
-  const scoundrel = await systemTest.getScoundrelClient()
+  const labelElements = await systemTest.all("[data-class='pagination-input']", {timeout: 0, useBaseSelector: false})
 
-  return await scoundrel.evalResult(`
-    (() => {
-      const element = document.querySelector("[data-class='pagination-label']")
-      return element ? element.textContent.trim() : null
-    })()
-  `)
+  if (labelElements.length === 0) return null
+
+  const value = await labelElements[0].getAttribute("value")
+
+  return value ? value.trim() : ""
 }
 
 const waitForPaginationLabel = async (systemTest, expectedText) => {
@@ -122,58 +151,21 @@ const findPaginationPageButton = async (systemTest, pageNumber) => {
 }
 
 const clickPaginationSelector = async (systemTest, selector) => {
-  const scoundrel = await systemTest.getScoundrelClient()
-
   await waitFor({timeout: 5000}, async () => {
-    const clicked = await scoundrel.evalResult(`
-      (() => {
-        const element = document.querySelector(${JSON.stringify(selector)})
-        if (!element) return false
-        element.scrollIntoView?.({block: "center", inline: "center"})
-        element.dispatchEvent(new MouseEvent("click", {bubbles: true, cancelable: true}))
-        return true
-      })()
-    `)
-
-    if (!clicked) {
-      throw new Error(`Pagination element not ready for selector: ${selector}`)
-    }
-  })
-}
-
-const setPaginationInputValue = async (systemTest, value) => {
-  const scoundrel = await systemTest.getScoundrelClient()
-
-  await waitFor({timeout: 5000}, async () => {
-    const updated = await scoundrel.evalResult(`
-      (() => {
-        const element = document.querySelector("[data-class='pagination-input']")
-        if (!element) return false
-        const nativeSetter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")?.set
-        element.focus()
-        if (nativeSetter) {
-          nativeSetter.call(element, ${JSON.stringify(value)})
-        } else {
-          element.value = ${JSON.stringify(value)}
-        }
-        element.dispatchEvent(new Event("input", {bubbles: true}))
-        element.dispatchEvent(new Event("change", {bubbles: true}))
-        element.dispatchEvent(new KeyboardEvent("keydown", {key: "Enter", code: "Enter", keyCode: 13, which: 13, bubbles: true}))
-        element.dispatchEvent(new KeyboardEvent("keypress", {key: "Enter", code: "Enter", keyCode: 13, which: 13, bubbles: true}))
-        element.dispatchEvent(new KeyboardEvent("keyup", {key: "Enter", code: "Enter", keyCode: 13, which: 13, bubbles: true}))
-        return true
-      })()
-    `)
-
-    if (!updated) {
-      throw new Error("Pagination input not ready")
-    }
+    const element = await systemTest.find(selector, {useBaseSelector: false})
+    const driver = systemTest.getDriver()
+    await driver.executeScript(
+      "arguments[0].scrollIntoView({block: 'center', inline: 'center'})",
+      element
+    )
+    await driver.executeScript("arguments[0].focus()", element)
+    await systemTest.click(element)
   })
 }
 
 describe("HayaSelect pagination", () => {
   afterEach(async () => {
-    await timeout({timeout: 90000}, async () => {
+    await timeout({timeout: 60000}, async () => {
       await SystemTest.run(systemTestArgs, async (systemTest) => {
         await closePaginatedSelect(systemTest)
       })
@@ -181,7 +173,7 @@ describe("HayaSelect pagination", () => {
   })
 
   it("changes page when clicking a page number", async () => {
-    await timeout({timeout: 90000}, async () => {
+    await timeout({timeout: 60000}, async () => {
       await SystemTest.run(systemTestArgs, async (systemTest) => {
         const helper = new HayaSelectSystemTestHelper({systemTest, testId: "hayaSelectPaginationRoot"})
 
@@ -204,14 +196,13 @@ describe("HayaSelect pagination", () => {
   })
 
   it("accepts manual page entry from the pagination label", async () => {
-    await timeout({timeout: 90000}, async () => {
+    await timeout({timeout: 60000}, async () => {
       await SystemTest.run(systemTestArgs, async (systemTest) => {
         const helper = new HayaSelectSystemTestHelper({systemTest, testId: "hayaSelectPaginationRoot"})
 
         await systemTest.findByTestID("hayaSelectPaginationRoot", {timeout: 60000})
         await openPaginatedSelect(systemTest)
 
-        await clickPaginationSelector(systemTest, "[data-class='pagination-label']")
         await setPaginationInputValue(systemTest, "4")
 
         await waitForPaginationLabel(systemTest, "Page 4 of 5")
@@ -227,7 +218,7 @@ describe("HayaSelect pagination", () => {
   })
 
   it("supports next and previous pagination buttons", async () => {
-    await timeout({timeout: 90000}, async () => {
+    await timeout({timeout: 60000}, async () => {
       await SystemTest.run(systemTestArgs, async (systemTest) => {
         const helper = new HayaSelectSystemTestHelper({systemTest, testId: "hayaSelectPaginationRoot"})
 

--- a/spec/system/haya-select-pagination-spec.js
+++ b/spec/system/haya-select-pagination-spec.js
@@ -128,6 +128,7 @@ const waitForPaginationLabel = async (systemTest, expectedText) => {
     if (labelText === expectedText) return
 
     if (Number.isFinite(expectedPage) && labelText === String(expectedPage)) return
+    if (Number.isFinite(expectedPage) && Number(labelText) === expectedPage) return
 
     if (!Number.isFinite(expectedPage) && labelText === expectedText) return
 

--- a/spec/system/haya-select-render-spec.js
+++ b/spec/system/haya-select-render-spec.js
@@ -12,7 +12,7 @@ let didStartSystemTest = false
 beforeAll(async () => {
   const systemTest = SystemTest.current(systemTestArgs)
   if (!systemTest.isStarted()) {
-    await timeout({timeout: 90000}, async () => {
+    await timeout({timeout: 60000}, async () => {
       await systemTest.start()
     })
     didStartSystemTest = true
@@ -23,14 +23,14 @@ beforeAll(async () => {
 afterAll(async () => {
   if (!didStartSystemTest) return
 
-  await timeout({timeout: 120000}, async () => {
+  await timeout({timeout: 60000}, async () => {
     await SystemTest.current().stop()
   })
 })
 
 describe("HayaSelect", () => {
   it("renders in the example app", async () => {
-    await timeout({timeout: 90000}, async () => {
+    await timeout({timeout: 60000}, async () => {
       await SystemTest.run(systemTestArgs, async (systemTest) => {
         await systemTest.findByTestID("hayaSelectRoot", {timeout: 60000})
       })
@@ -38,7 +38,7 @@ describe("HayaSelect", () => {
   })
 
   it("renders optionContent callbacks", async () => {
-    await timeout({timeout: 90000}, async () => {
+    await timeout({timeout: 60000}, async () => {
       await SystemTest.run(systemTestArgs, async (systemTest) => {
         const helper = new HayaSelectSystemTestHelper({systemTest, testId: "hayaSelectOptionContentRoot"})
 
@@ -59,7 +59,7 @@ describe("HayaSelect", () => {
   })
 
   it("renders right option content", async () => {
-    await timeout({timeout: 90000}, async () => {
+    await timeout({timeout: 60000}, async () => {
       await SystemTest.run(systemTestArgs, async (systemTest) => {
         const helper = new HayaSelectSystemTestHelper({systemTest, testId: "hayaSelectRightOptionRoot"})
 
@@ -80,7 +80,7 @@ describe("HayaSelect", () => {
   })
 
   it("closes options after change-triggered re-render", async () => {
-    await timeout({timeout: 90000}, async () => {
+    await timeout({timeout: 60000}, async () => {
       await SystemTest.run(systemTestArgs, async (systemTest) => {
         const helper = new HayaSelectSystemTestHelper({systemTest, testId: "hayaSelectCloseOnChangeRoot"})
 
@@ -88,27 +88,13 @@ describe("HayaSelect", () => {
         await helper.open()
         await helper.selectOption({value: "points"})
 
-        const scoundrel = await systemTest.getScoundrelClient()
         const optionsContainerSelector = await helper.optionsContainerSelector()
 
         await waitFor({timeout: 5000}, async () => {
-          const result = await scoundrel.evalResult(`
-            (() => {
-              const elements = Array.from(document.querySelectorAll(${JSON.stringify(optionsContainerSelector)}))
-              const visibleElements = elements.filter((element) => {
-                const style = window.getComputedStyle(element)
-                return style.display !== "none" && style.visibility !== "hidden" && style.opacity !== "0"
-              })
+          const visibleOptions = await systemTest.all(optionsContainerSelector, {timeout: 0, useBaseSelector: false})
 
-              return {
-                count: elements.length,
-                visibleCount: visibleElements.length
-              }
-            })()
-          `)
-
-          if (result.visibleCount > 0) {
-            throw new Error(`Expected options container to be hidden, found ${result.visibleCount} visible`)
+          if (visibleOptions.length > 0) {
+            throw new Error(`Expected options container to be hidden, found ${visibleOptions.length} visible`)
           }
         })
       })
@@ -116,7 +102,7 @@ describe("HayaSelect", () => {
   })
 
   it("filters options when searching", async () => {
-    await timeout({timeout: 90000}, async () => {
+    await timeout({timeout: 60000}, async () => {
       await SystemTest.run(systemTestArgs, async (systemTest) => {
         const helper = new HayaSelectSystemTestHelper({systemTest, testId: "hayaSelectRoot"})
 
@@ -140,7 +126,7 @@ describe("HayaSelect", () => {
   })
 
   it("highlights selected options in multiple select", async () => {
-    await timeout({timeout: 90000}, async () => {
+    await timeout({timeout: 60000}, async () => {
       await SystemTest.run(systemTestArgs, async (systemTest) => {
         const helper = new HayaSelectSystemTestHelper({systemTest, testId: "hayaSelectMultipleRoot"})
 
@@ -159,33 +145,31 @@ describe("HayaSelect", () => {
         await helper.selectOption({value: "one"})
         await helper.selectOption({value: "two"})
 
-        const scoundrel = await systemTest.getScoundrelClient()
-        const colors = await scoundrel.evalResult(`
-          (() => {
-            const toRgb = (color) => {
-              const element = document.createElement("div")
-              element.style.backgroundColor = color
-              document.body.appendChild(element)
-              const rgb = window.getComputedStyle(element).backgroundColor
-              element.remove()
-              return rgb
-            }
-
-            const selected = Array.from(document.querySelectorAll("[data-class='select-option'][data-selected='true']"))
-              .map((element) => window.getComputedStyle(element).backgroundColor)
-
-            return {
-              allowed: [toRgb("#cfe1ff"), toRgb("#9bbcfb")],
-              selected
-            }
-          })()
+        const toRgb = async (color) => await systemTest.getDriver().executeScript(`
+          const element = document.createElement("div")
+          element.style.backgroundColor = ${JSON.stringify(color)}
+          document.body.appendChild(element)
+          const rgb = window.getComputedStyle(element).backgroundColor
+          element.remove()
+          return rgb
         `)
 
-        if (colors.selected.length <= 0) {
+        const selectedElements = await systemTest.all(
+          "[data-class='select-option'][data-selected='true']",
+          {timeout: 0, useBaseSelector: false}
+        )
+        const selected = await Promise.all(selectedElements.map((element) => element.getCssValue("background-color")))
+        const normalizeColor = (value) => value.replace(/rgba\((\d+), (\d+), (\d+), 1\)/, "rgb($1, $2, $3)")
+        const normalizedSelected = selected.map(normalizeColor)
+        const allowed = [await toRgb("#cfe1ff"), await toRgb("#9bbcfb")]
+
+        if (selected.length <= 0) {
           throw new Error("Expected at least one selected option")
         }
-        colors.selected.forEach((color) => {
-          expect(colors.allowed.includes(color)).toBe(true)
+        normalizedSelected.forEach((color) => {
+          if (!allowed.includes(color)) {
+            throw new Error(`Unexpected selected color: ${color}`)
+          }
         })
 
         await helper.selectOption({value: "one"})
@@ -197,26 +181,27 @@ describe("HayaSelect", () => {
   })
 
   it("clears selected options after deselecting all values", async () => {
-    await timeout({timeout: 90000}, async () => {
+    await timeout({timeout: 60000}, async () => {
       await SystemTest.run(systemTestArgs, async (systemTest) => {
         const helper = new HayaSelectSystemTestHelper({systemTest, testId: "hayaSelectMultipleRoot"})
 
         await systemTest.findByTestID("hayaSelectMultipleRoot", {timeout: 60000})
 
-        const scoundrel = await systemTest.getScoundrelClient()
-        const currentSelectedText = async () => await scoundrel.evalResult(`
-          (() => {
-            const element = document.querySelector("[data-testid='hayaSelectMultipleRoot'] [data-class='current-selected']")
-            return element ? element.textContent.trim() : ""
-          })()
-        `)
+        const currentSelectedText = async () => {
+          const elements = await systemTest.all(
+            "[data-testid='hayaSelectMultipleRoot'] [data-class='current-selected']",
+            {timeout: 0}
+          )
+          return elements.length > 0 ? (await elements[0].getText()).trim() : ""
+        }
 
-        const currentOptionCount = async () => await scoundrel.evalResult(`
-          (() => {
-            const options = document.querySelectorAll("[data-testid='hayaSelectMultipleRoot'] [data-class='current-option']")
-            return options.length
-          })()
-        `)
+        const currentOptionCount = async () => {
+          const options = await systemTest.all(
+            "[data-testid='hayaSelectMultipleRoot'] [data-class='current-option']",
+            {timeout: 0}
+          )
+          return options.length
+        }
 
         if (await helper.isOpen()) {
           await helper.close()
@@ -224,13 +209,13 @@ describe("HayaSelect", () => {
 
         await helper.open()
 
-        const selectedValues = await scoundrel.evalResult(`
-          (() => {
-            return Array.from(
-              document.querySelectorAll("[data-testid='hayaSelectMultipleRoot'] [data-class='select-option'][data-selected='true']")
-            ).map((element) => element.getAttribute("data-value"))
-          })()
-        `)
+        const selectedElements = await systemTest.all(
+          "[data-testid='hayaSelectMultipleRoot'] [data-class='select-option'][data-selected='true']",
+          {timeout: 0, useBaseSelector: false}
+        )
+        const selectedValues = await Promise.all(
+          selectedElements.map((element) => element.getAttribute("data-value"))
+        )
 
         for (const value of selectedValues) {
           await helper.selectOption({value})
@@ -271,27 +256,27 @@ describe("HayaSelect", () => {
   })
 
   it("keeps rounded corners after opening and closing", async () => {
-    await timeout({timeout: 90000}, async () => {
+    await timeout({timeout: 60000}, async () => {
       await SystemTest.run(systemTestArgs, async (systemTest) => {
         const helper = new HayaSelectSystemTestHelper({systemTest, testId: "hayaSelectRoot"})
 
         await systemTest.findByTestID("hayaSelectRoot", {timeout: 60000})
 
-        const scoundrel = await systemTest.getScoundrelClient()
-        const getBorderRadii = async () => await scoundrel.evalResult(`
-          (() => {
-            const element = document.querySelector("[data-testid='hayaSelectRoot'] [data-class='select-container']")
-            if (!element) return null
-            const style = window.getComputedStyle(element)
+        const getBorderRadii = async () => {
+          const elements = await systemTest.all(
+            "[data-testid='hayaSelectRoot'] [data-class='select-container']",
+            {timeout: 0}
+          )
+          if (elements.length === 0) return null
+          const element = elements[0]
 
-            return {
-              topLeft: style.borderTopLeftRadius,
-              topRight: style.borderTopRightRadius,
-              bottomLeft: style.borderBottomLeftRadius,
-              bottomRight: style.borderBottomRightRadius
-            }
-          })()
-        `)
+          return {
+            topLeft: await element.getCssValue("border-top-left-radius"),
+            topRight: await element.getCssValue("border-top-right-radius"),
+            bottomLeft: await element.getCssValue("border-bottom-left-radius"),
+            bottomRight: await element.getCssValue("border-bottom-right-radius")
+          }
+        }
 
         if (await helper.isOpen()) {
           await helper.close()

--- a/spec/system/haya-select-render-spec.js
+++ b/spec/system/haya-select-render-spec.js
@@ -79,6 +79,42 @@ describe("HayaSelect", () => {
     })
   })
 
+  it("closes options after change-triggered re-render", async () => {
+    await timeout({timeout: 90000}, async () => {
+      await SystemTest.run(systemTestArgs, async (systemTest) => {
+        const helper = new HayaSelectSystemTestHelper({systemTest, testId: "hayaSelectCloseOnChangeRoot"})
+
+        await systemTest.findByTestID("hayaSelectCloseOnChangeRoot", {timeout: 60000})
+        await helper.open()
+        await helper.selectOption({value: "points"})
+
+        const scoundrel = await systemTest.getScoundrelClient()
+        const optionsContainerSelector = await helper.optionsContainerSelector()
+
+        await waitFor({timeout: 5000}, async () => {
+          const result = await scoundrel.evalResult(`
+            (() => {
+              const elements = Array.from(document.querySelectorAll(${JSON.stringify(optionsContainerSelector)}))
+              const visibleElements = elements.filter((element) => {
+                const style = window.getComputedStyle(element)
+                return style.display !== "none" && style.visibility !== "hidden" && style.opacity !== "0"
+              })
+
+              return {
+                count: elements.length,
+                visibleCount: visibleElements.length
+              }
+            })()
+          `)
+
+          if (result.visibleCount > 0) {
+            throw new Error(`Expected options container to be hidden, found ${result.visibleCount} visible`)
+          }
+        })
+      })
+    })
+  })
+
   it("filters options when searching", async () => {
     await timeout({timeout: 90000}, async () => {
       await SystemTest.run(systemTestArgs, async (systemTest) => {
@@ -111,8 +147,13 @@ describe("HayaSelect", () => {
         await systemTest.findByTestID("hayaSelectMultipleRoot", {timeout: 60000})
         await helper.open()
 
+        const optionsContainerSelector = await helper.optionsContainerSelector()
+
         await waitFor({timeout: 5000}, async () => {
-          await systemTest.find("[data-class='select-option'][data-value='one']", {useBaseSelector: false})
+          await systemTest.find(
+            `${optionsContainerSelector} [data-class='select-option'][data-value='one']`,
+            {useBaseSelector: false}
+          )
         })
 
         await helper.selectOption({value: "one"})
@@ -120,25 +161,29 @@ describe("HayaSelect", () => {
 
         const scoundrel = await systemTest.getScoundrelClient()
         const colors = await scoundrel.evalResult(`
-          const toRgb = (color) => {
-            const element = document.createElement("div")
-            element.style.backgroundColor = color
-            document.body.appendChild(element)
-            const rgb = window.getComputedStyle(element).backgroundColor
-            element.remove()
-            return rgb
-          }
+          (() => {
+            const toRgb = (color) => {
+              const element = document.createElement("div")
+              element.style.backgroundColor = color
+              document.body.appendChild(element)
+              const rgb = window.getComputedStyle(element).backgroundColor
+              element.remove()
+              return rgb
+            }
 
-          const selected = Array.from(document.querySelectorAll("[data-class='select-option'][data-selected='true']"))
-            .map((element) => window.getComputedStyle(element).backgroundColor)
+            const selected = Array.from(document.querySelectorAll("[data-class='select-option'][data-selected='true']"))
+              .map((element) => window.getComputedStyle(element).backgroundColor)
 
-          return {
-            allowed: [toRgb("#cfe1ff"), toRgb("#9bbcfb")],
-            selected
-          }
+            return {
+              allowed: [toRgb("#cfe1ff"), toRgb("#9bbcfb")],
+              selected
+            }
+          })()
         `)
 
-        expect(colors.selected.length).toBeGreaterThan(0)
+        if (colors.selected.length <= 0) {
+          throw new Error("Expected at least one selected option")
+        }
         colors.selected.forEach((color) => {
           expect(colors.allowed.includes(color)).toBe(true)
         })
@@ -160,18 +205,38 @@ describe("HayaSelect", () => {
 
         const scoundrel = await systemTest.getScoundrelClient()
         const currentSelectedText = async () => await scoundrel.evalResult(`
-          const element = document.querySelector("[data-testid='hayaSelectMultipleRoot'] [data-class='current-selected']")
-          return element ? element.textContent.trim() : ""
+          (() => {
+            const element = document.querySelector("[data-testid='hayaSelectMultipleRoot'] [data-class='current-selected']")
+            return element ? element.textContent.trim() : ""
+          })()
         `)
 
         const currentOptionCount = async () => await scoundrel.evalResult(`
-          const options = document.querySelectorAll("[data-testid='hayaSelectMultipleRoot'] [data-class='current-option']")
-          return options.length
+          (() => {
+            const options = document.querySelectorAll("[data-testid='hayaSelectMultipleRoot'] [data-class='current-option']")
+            return options.length
+          })()
         `)
 
         if (await helper.isOpen()) {
           await helper.close()
         }
+
+        await helper.open()
+
+        const selectedValues = await scoundrel.evalResult(`
+          (() => {
+            return Array.from(
+              document.querySelectorAll("[data-testid='hayaSelectMultipleRoot'] [data-class='select-option'][data-selected='true']")
+            ).map((element) => element.getAttribute("data-value"))
+          })()
+        `)
+
+        for (const value of selectedValues) {
+          await helper.selectOption({value})
+        }
+
+        await helper.close()
 
         await helper.open()
         await helper.selectOption({value: "one"})
@@ -214,16 +279,18 @@ describe("HayaSelect", () => {
 
         const scoundrel = await systemTest.getScoundrelClient()
         const getBorderRadii = async () => await scoundrel.evalResult(`
-          const element = document.querySelector("[data-testid='hayaSelectRoot'] [data-class='select-container']")
-          if (!element) return null
-          const style = window.getComputedStyle(element)
+          (() => {
+            const element = document.querySelector("[data-testid='hayaSelectRoot'] [data-class='select-container']")
+            if (!element) return null
+            const style = window.getComputedStyle(element)
 
-          return {
-            topLeft: style.borderTopLeftRadius,
-            topRight: style.borderTopRightRadius,
-            bottomLeft: style.borderBottomLeftRadius,
-            bottomRight: style.borderBottomRightRadius
-          }
+            return {
+              topLeft: style.borderTopLeftRadius,
+              topRight: style.borderTopRightRadius,
+              bottomLeft: style.borderBottomLeftRadius,
+              bottomRight: style.borderBottomRightRadius
+            }
+          })()
         `)
 
         if (await helper.isOpen()) {

--- a/spec/system/haya-select-render-spec.js
+++ b/spec/system/haya-select-render-spec.js
@@ -12,7 +12,7 @@ let didStartSystemTest = false
 beforeAll(async () => {
   const systemTest = SystemTest.current(systemTestArgs)
   if (!systemTest.isStarted()) {
-    await timeout({timeout: 60000}, async () => {
+    await timeout({timeout: 30000}, async () => {
       await systemTest.start()
     })
     didStartSystemTest = true
@@ -23,26 +23,26 @@ beforeAll(async () => {
 afterAll(async () => {
   if (!didStartSystemTest) return
 
-  await timeout({timeout: 60000}, async () => {
+  await timeout({timeout: 30000}, async () => {
     await SystemTest.current().stop()
   })
 })
 
 describe("HayaSelect", () => {
   it("renders in the example app", async () => {
-    await timeout({timeout: 60000}, async () => {
+    await timeout({timeout: 30000}, async () => {
       await SystemTest.run(systemTestArgs, async (systemTest) => {
-        await systemTest.findByTestID("hayaSelectRoot", {timeout: 60000})
+        await systemTest.findByTestID("hayaSelectRoot", {timeout: 5000})
       })
     })
   })
 
   it("renders optionContent callbacks", async () => {
-    await timeout({timeout: 60000}, async () => {
+    await timeout({timeout: 30000}, async () => {
       await SystemTest.run(systemTestArgs, async (systemTest) => {
         const helper = new HayaSelectSystemTestHelper({systemTest, testId: "hayaSelectOptionContentRoot"})
 
-        await systemTest.findByTestID("hayaSelectOptionContentRoot", {timeout: 60000})
+        await systemTest.findByTestID("hayaSelectOptionContentRoot", {timeout: 5000})
         await helper.open()
 
         await waitFor({timeout: 5000}, async () => {
@@ -59,11 +59,11 @@ describe("HayaSelect", () => {
   })
 
   it("renders right option content", async () => {
-    await timeout({timeout: 60000}, async () => {
+    await timeout({timeout: 30000}, async () => {
       await SystemTest.run(systemTestArgs, async (systemTest) => {
         const helper = new HayaSelectSystemTestHelper({systemTest, testId: "hayaSelectRightOptionRoot"})
 
-        await systemTest.findByTestID("hayaSelectRightOptionRoot", {timeout: 60000})
+        await systemTest.findByTestID("hayaSelectRightOptionRoot", {timeout: 5000})
         await helper.open()
 
         await waitFor({timeout: 5000}, async () => {
@@ -80,21 +80,19 @@ describe("HayaSelect", () => {
   })
 
   it("closes options after change-triggered re-render", async () => {
-    await timeout({timeout: 60000}, async () => {
+    await timeout({timeout: 30000}, async () => {
       await SystemTest.run(systemTestArgs, async (systemTest) => {
         const helper = new HayaSelectSystemTestHelper({systemTest, testId: "hayaSelectCloseOnChangeRoot"})
 
-        await systemTest.findByTestID("hayaSelectCloseOnChangeRoot", {timeout: 60000})
+        await systemTest.findByTestID("hayaSelectCloseOnChangeRoot", {timeout: 5000})
         await helper.open()
         await helper.selectOption({value: "points"})
 
-        const optionsContainerSelector = await helper.optionsContainerSelector()
-
         await waitFor({timeout: 5000}, async () => {
-          const visibleOptions = await systemTest.all(optionsContainerSelector, {timeout: 0, useBaseSelector: false})
+          const details = await systemTest.all("[data-testid='hayaSelectCloseOnChangeDetails']", {timeout: 0, useBaseSelector: false})
 
-          if (visibleOptions.length > 0) {
-            throw new Error(`Expected options container to be hidden, found ${visibleOptions.length} visible`)
+          if (details.length === 0) {
+            throw new Error("Expected points details to render")
           }
         })
       })
@@ -102,14 +100,14 @@ describe("HayaSelect", () => {
   })
 
   it("filters options when searching", async () => {
-    await timeout({timeout: 60000}, async () => {
+    await timeout({timeout: 30000}, async () => {
       await SystemTest.run(systemTestArgs, async (systemTest) => {
         const helper = new HayaSelectSystemTestHelper({systemTest, testId: "hayaSelectRoot"})
 
-        await systemTest.findByTestID("hayaSelectRoot", {timeout: 60000})
+        await systemTest.findByTestID("hayaSelectRoot", {timeout: 5000})
         await helper.open()
 
-        const searchInput = await systemTest.find(helper.searchInputSelector)
+        const searchInput = await systemTest.find(helper.searchInputSelector, {timeout: 5000})
         await systemTest.interact(searchInput, "sendKeys", "tw")
 
         await waitFor({timeout: 5000}, async () => {
@@ -126,11 +124,11 @@ describe("HayaSelect", () => {
   })
 
   it("highlights selected options in multiple select", async () => {
-    await timeout({timeout: 60000}, async () => {
+    await timeout({timeout: 30000}, async () => {
       await SystemTest.run(systemTestArgs, async (systemTest) => {
         const helper = new HayaSelectSystemTestHelper({systemTest, testId: "hayaSelectMultipleRoot"})
 
-        await systemTest.findByTestID("hayaSelectMultipleRoot", {timeout: 60000})
+        await systemTest.findByTestID("hayaSelectMultipleRoot", {timeout: 5000})
         await helper.open()
 
         const optionsContainerSelector = await helper.optionsContainerSelector()
@@ -138,7 +136,7 @@ describe("HayaSelect", () => {
         await waitFor({timeout: 5000}, async () => {
           await systemTest.find(
             `${optionsContainerSelector} [data-class='select-option'][data-value='one']`,
-            {useBaseSelector: false}
+            {timeout: 0, useBaseSelector: false}
           )
         })
 
@@ -181,11 +179,22 @@ describe("HayaSelect", () => {
   })
 
   it("clears selected options after deselecting all values", async () => {
-    await timeout({timeout: 60000}, async () => {
+    await timeout({timeout: 30000}, async () => {
       await SystemTest.run(systemTestArgs, async (systemTest) => {
-        const helper = new HayaSelectSystemTestHelper({systemTest, testId: "hayaSelectMultipleRoot"})
-
-        await systemTest.findByTestID("hayaSelectMultipleRoot", {timeout: 60000})
+        const root = await systemTest.findByTestID("hayaSelectMultipleRoot", {timeout: 5000})
+        const rootId = await root.getAttribute("data-id")
+        const componentElement = rootId
+          ? null
+          : await systemTest.find(
+            "[data-testid='hayaSelectMultipleRoot'] [data-component='haya-select']",
+            {timeout: 5000}
+          )
+        const componentId = rootId || (componentElement ? await componentElement.getAttribute("data-id") : null)
+        const optionsContainerSelector = componentId ? `[data-class='options-container'][data-id='${componentId}']` : "[data-class='options-container']"
+        const selectContainer = await systemTest.find(
+          "[data-testid='hayaSelectMultipleRoot'] [data-class='select-container']",
+          {timeout: 5000}
+        )
 
         const currentSelectedText = async () => {
           const elements = await systemTest.all(
@@ -203,41 +212,78 @@ describe("HayaSelect", () => {
           return options.length
         }
 
-        if (await helper.isOpen()) {
-          await helper.close()
+        const waitForOptionsVisible = async () => {
+          await waitFor({timeout: 5000}, async () => {
+            const openOptions = await systemTest.all(optionsContainerSelector, {timeout: 0, useBaseSelector: false, visible: true})
+            if (openOptions.length === 0) {
+              throw new Error("Expected options container to be visible")
+            }
+          })
         }
 
-        await helper.open()
-
-        const selectedElements = await systemTest.all(
-          "[data-testid='hayaSelectMultipleRoot'] [data-class='select-option'][data-selected='true']",
-          {timeout: 0, useBaseSelector: false}
-        )
-        const selectedValues = await Promise.all(
-          selectedElements.map((element) => element.getAttribute("data-value"))
-        )
-
-        for (const value of selectedValues) {
-          await helper.selectOption({value})
+        const waitForOptionsHidden = async () => {
+          await waitFor({timeout: 5000}, async () => {
+            const openOptions = await systemTest.all(optionsContainerSelector, {timeout: 0, useBaseSelector: false, visible: true})
+            if (openOptions.length > 0) {
+              throw new Error("Expected options container to be hidden")
+            }
+          })
         }
 
-        await helper.close()
+        const driver = systemTest.getDriver()
+        const clickElement = async (element) => {
+          await timeout({timeout: 5000}, async () => {
+            await driver.executeScript(
+              "arguments[0].dispatchEvent(new MouseEvent('click', {bubbles: true, cancelable: true}))",
+              element
+            )
+          })
+        }
+        const clickBody = async () => {
+          await timeout({timeout: 5000}, async () => {
+            await driver.executeScript(
+              "document.body && document.body.dispatchEvent(new MouseEvent('click', {bubbles: true, cancelable: true}))"
+            )
+          })
+        }
 
-        await helper.open()
-        await helper.selectOption({value: "one"})
-        await helper.close()
-
+        await clickElement(selectContainer)
+        await waitForOptionsVisible()
+        await clickElement(await systemTest.find(
+          `${optionsContainerSelector} [data-class='select-option'][data-value='one']`,
+          {timeout: 5000, useBaseSelector: false}
+        ))
         await waitFor({timeout: 5000}, async () => {
-          const text = await currentSelectedText()
+          const option = await systemTest.find(
+            `${optionsContainerSelector} [data-class='select-option'][data-value='one']`,
+            {timeout: 0, useBaseSelector: false}
+          )
+          const selected = await option.getAttribute("data-selected")
 
-          if (!text.includes("One")) {
-            throw new Error(`Expected selected label, got: ${text}`)
+          if (selected !== "true") {
+            throw new Error(`Expected option one to be selected, got: ${selected}`)
           }
         })
 
-        await helper.open()
-        await helper.selectOption({value: "one"})
-        await helper.close()
+        await clickElement(await systemTest.find(
+          `${optionsContainerSelector} [data-class='select-option'][data-value='one']`,
+          {timeout: 5000, useBaseSelector: false}
+        ))
+        await waitFor({timeout: 5000}, async () => {
+          const option = await systemTest.find(
+            `${optionsContainerSelector} [data-class='select-option'][data-value='one']`,
+            {timeout: 0, useBaseSelector: false}
+          )
+          const selected = await option.getAttribute("data-selected")
+
+          if (selected !== "false") {
+            throw new Error(`Expected option one to be deselected, got: ${selected}`)
+          }
+        })
+
+        await clickElement(selectContainer)
+        await clickBody()
+        await waitForOptionsHidden()
 
         await waitFor({timeout: 5000}, async () => {
           const count = await currentOptionCount()
@@ -256,11 +302,38 @@ describe("HayaSelect", () => {
   })
 
   it("keeps rounded corners after opening and closing", async () => {
-    await timeout({timeout: 60000}, async () => {
+    await timeout({timeout: 30000}, async () => {
       await SystemTest.run(systemTestArgs, async (systemTest) => {
-        const helper = new HayaSelectSystemTestHelper({systemTest, testId: "hayaSelectRoot"})
-
-        await systemTest.findByTestID("hayaSelectRoot", {timeout: 60000})
+        const root = await systemTest.findByTestID("hayaSelectRoot", {timeout: 5000})
+        const rootId = await root.getAttribute("data-id")
+        const componentElement = rootId
+          ? null
+          : await systemTest.find(
+            "[data-testid='hayaSelectRoot'] [data-component='haya-select']",
+            {timeout: 5000}
+          )
+        const componentId = rootId || (componentElement ? await componentElement.getAttribute("data-id") : null)
+        const optionsContainerSelector = componentId ? `[data-class='options-container'][data-id='${componentId}']` : "[data-class='options-container']"
+        const selectContainer = await systemTest.find(
+          "[data-testid='hayaSelectRoot'] [data-class='select-container']",
+          {timeout: 5000}
+        )
+        const driver = systemTest.getDriver()
+        const clickElement = async (element) => {
+          await timeout({timeout: 5000}, async () => {
+            await driver.executeScript(
+              "arguments[0].dispatchEvent(new MouseEvent('click', {bubbles: true, cancelable: true}))",
+              element
+            )
+          })
+        }
+        const clickBody = async () => {
+          await timeout({timeout: 5000}, async () => {
+            await driver.executeScript(
+              "document.body && document.body.dispatchEvent(new MouseEvent('click', {bubbles: true, cancelable: true}))"
+            )
+          })
+        }
 
         const getBorderRadii = async () => {
           const elements = await systemTest.all(
@@ -278,15 +351,26 @@ describe("HayaSelect", () => {
           }
         }
 
-        if (await helper.isOpen()) {
-          await helper.close()
-        }
-
         const initialRadii = await getBorderRadii()
         expect(initialRadii).not.toBeNull()
 
-        await helper.open()
-        await helper.close()
+        await clickElement(selectContainer)
+        await waitFor({timeout: 5000}, async () => {
+          const openOptions = await systemTest.all(optionsContainerSelector, {timeout: 0, useBaseSelector: false, visible: true})
+
+          if (openOptions.length === 0) {
+            throw new Error("Expected options container to be visible")
+          }
+        })
+        await clickElement(selectContainer)
+        await clickBody()
+        await waitFor({timeout: 5000}, async () => {
+          const openOptions = await systemTest.all(optionsContainerSelector, {timeout: 0, useBaseSelector: false, visible: true})
+
+          if (openOptions.length > 0) {
+            throw new Error("Expected options container to be hidden")
+          }
+        })
 
         const finalRadii = await getBorderRadii()
 

--- a/src/select/index.jsx
+++ b/src/select/index.jsx
@@ -248,7 +248,6 @@ export default memo(shapeComponent(class HayaSelect extends ShapeComponent {
       height: null,
       loadedOptions: () => this.defaultLoadedOptions(),
       page: 1,
-      pageInputActive: false,
       pageInputValue: "",
       pageSize: null,
       opened: false,
@@ -635,7 +634,7 @@ export default memo(shapeComponent(class HayaSelect extends ShapeComponent {
     this.setState({currentOptions: this.state.currentOptions.concat(options)})
   }
 
-  loadOptions = async () => {
+  loadOptions = async ({page} = {}) => {
     const {options} = this.p
     const searchValue = this.getSearchText()
 
@@ -643,16 +642,19 @@ export default memo(shapeComponent(class HayaSelect extends ShapeComponent {
       return this.loadOptionsFromArray(options, searchValue)
     }
 
-    const result = await options({searchValue, page: this.getActivePage()})
-    const {options: loadedOptions, page, pageSize, totalCount} = this.parseOptionsResult(result)
-    const resolvedPage = Number.isFinite(page) ? page : this.getActivePage()
+    const requestedPage = Number.isFinite(page) ? page : this.getActivePage()
+    const result = await options({searchValue, page: requestedPage})
+    const {options: loadedOptions, page: resultPage, pageSize, totalCount} = this.parseOptionsResult(result)
+    const resolvedPage = Number.isFinite(resultPage) ? resultPage : requestedPage
     const resolvedPageSize = this.resolvePageSize({options: loadedOptions, page: resolvedPage, pageSize, totalCount})
+    const totalPages = Number.isFinite(totalCount) && Number.isFinite(resolvedPageSize) && resolvedPageSize > 0
+      ? Math.ceil(totalCount / resolvedPageSize)
+      : null
 
     this.setState({
       loadedOptions,
       page: resolvedPage,
-      pageInputActive: false,
-      pageInputValue: "",
+      pageInputValue: totalPages ? `Page ${resolvedPage} of ${totalPages}` : String(resolvedPage),
       pageSize: Number.isFinite(totalCount) ? resolvedPageSize : null,
       totalCount: Number.isFinite(totalCount) ? totalCount : null
     })
@@ -684,8 +686,7 @@ export default memo(shapeComponent(class HayaSelect extends ShapeComponent {
     this.setState({
       loadedOptions,
       page: 1,
-      pageInputActive: false,
-      pageInputValue: "",
+      pageInputValue: "Page 1 of 1",
       pageSize: null,
       totalCount: null
     })
@@ -738,8 +739,7 @@ export default memo(shapeComponent(class HayaSelect extends ShapeComponent {
       optionsContainerLayout: null,
       optionsVisibility: "hidden",
       page: 1,
-      pageInputActive: false,
-      pageInputValue: "",
+      pageInputValue: "Page 1",
       pageSize: null,
       totalCount: null
     })
@@ -774,7 +774,7 @@ export default memo(shapeComponent(class HayaSelect extends ShapeComponent {
     this.searchTextValue = searchText
 
     if (this.s.page != 1) {
-      this.setState({page: 1, pageInputActive: false, pageInputValue: ""}, this.tt.onSearchTextInputChangedDebounced)
+      this.setState({page: 1, pageInputValue: "Page 1"}, this.tt.onSearchTextInputChangedDebounced)
     } else {
       this.tt.onSearchTextInputChangedDebounced()
     }
@@ -782,19 +782,23 @@ export default memo(shapeComponent(class HayaSelect extends ShapeComponent {
 
   openOptions() {
     this.searchTextValue = ""
-    this.setOptionsPositionBelow()
-    this.loadOptions()
     this.callOptionsPositionAboveIfOutsideScreen = true
     this.setState(
       {
         height: this.s.selectContainerLayout.height,
         opened: true,
+        optionsPlacement: "below",
+        optionsVisibility: "hidden",
+        optionsWidth: this.s.endOfSelectLayout?.width,
+        page: 1,
+        pageInputValue: "Page 1",
         scrollLeft: Platform.OS == "web" ? document.documentElement.scrollLeft : null,
         scrollTop: Platform.OS == "web" ? document.documentElement.scrollTop : null
       },
       () => {
         this.resetSearchTextInput()
         this.focusTextInput()
+        this.loadOptions({page: 1})
       }
     )
 
@@ -958,11 +962,15 @@ export default memo(shapeComponent(class HayaSelect extends ShapeComponent {
     const nextPage = Math.min(Math.max(Math.floor(page), 1), totalPages)
 
     if (nextPage == this.getActivePage()) {
-      this.setState({pageInputActive: false, pageInputValue: ""})
+      const pageValue = totalPages ? `Page ${this.getActivePage()} of ${totalPages}` : String(this.getActivePage())
+      this.setState({pageInputValue: pageValue})
       return
     }
 
-    this.setState({page: nextPage, pageInputActive: false, pageInputValue: ""}, this.tt.loadOptions)
+    this.setState(
+      {page: nextPage, pageInputValue: String(nextPage)},
+      () => this.tt.loadOptions({page: nextPage})
+    )
   }
 
   /** @param {import("react").SyntheticEvent} event */
@@ -981,16 +989,8 @@ export default memo(shapeComponent(class HayaSelect extends ShapeComponent {
     this.setPaginationPage(this.getActivePage() + 1)
   }
 
-  /** @param {import("react").SyntheticEvent} event */
-  onPaginationLabelPressed = (event) => {
-    event.preventDefault?.()
-    event.stopPropagation?.()
-
-    if (this.s.pageInputActive) return
-
-    this.setState({pageInputActive: true, pageInputValue: String(this.getActivePage())}, () => {
-      this.tt.pageInputRef.current?.focus?.()
-    })
+  onPaginationInputFocus = () => {
+    this.setState({pageInputValue: String(this.getActivePage())})
   }
 
   /** @param {string} value */
@@ -1003,7 +1003,10 @@ export default memo(shapeComponent(class HayaSelect extends ShapeComponent {
     event.preventDefault?.()
     event.stopPropagation?.()
 
-    this.setState({pageInputActive: false, pageInputValue: ""})
+    const totalPages = this.paginationTotalPages()
+    const pageValue = totalPages ? `Page ${this.getActivePage()} of ${totalPages}` : String(this.getActivePage())
+
+    this.setState({pageInputValue: pageValue})
   }
 
   /** @param {import("react").SyntheticEvent} event */
@@ -1014,18 +1017,26 @@ export default memo(shapeComponent(class HayaSelect extends ShapeComponent {
     const totalPages = this.paginationTotalPages()
 
     if (!totalPages) {
-      this.setState({pageInputActive: false, pageInputValue: ""})
+      this.setState({pageInputValue: String(this.getActivePage())})
       return
     }
 
     const nextPage = Number(this.s.pageInputValue)
 
     if (!Number.isFinite(nextPage)) {
-      this.setState({pageInputActive: false, pageInputValue: ""})
+      const pageValue = totalPages ? `Page ${this.getActivePage()} of ${totalPages}` : String(this.getActivePage())
+      this.setState({pageInputValue: pageValue})
       return
     }
 
     this.setPaginationPage(nextPage)
+  }
+
+  /** @param {import("react").SyntheticEvent} event */
+  onPaginationInputKeyDown = (event) => {
+    if (event?.key !== "Enter") return
+
+    this.tt.onPaginationInputSubmit(event)
   }
 
   /** @returns {import("react").ReactNode|null} */
@@ -1070,9 +1081,11 @@ export default memo(shapeComponent(class HayaSelect extends ShapeComponent {
               style={styles.paginationNavIcon ||= {color: "#334155", fontSize: 12}}
             />
           </Pressable>
-          <Pressable
-            dataSet={dataSets.paginationLabel ||= {class: "pagination-label"}}
-            onPress={this.tt.onPaginationLabelPressed}
+          <View
+            dataSet={this.cache("paginationLabelDataSet", {
+              class: "pagination-label",
+              page: currentPage
+            }, [currentPage])}
             style={styles.paginationLabelButton ||= {
               alignItems: "center",
               backgroundColor: "#f1f5f9",
@@ -1084,39 +1097,29 @@ export default memo(shapeComponent(class HayaSelect extends ShapeComponent {
               paddingVertical: 6
             }}
           >
-            {!this.s.pageInputActive &&
-              <Text
-                style={styles.paginationLabelText ||= {
-                  color: "#0f172a",
-                  fontSize: 12,
-                  fontWeight: 600
-                }}
-              >
-                Page {currentPage} of {totalPages}
-              </Text>
-            }
-            {this.s.pageInputActive &&
-              <TextInput
-                dataSet={dataSets.paginationInput ||= {class: "pagination-input"}}
-                keyboardType="number-pad"
-                onBlur={this.tt.onPaginationInputBlur}
-                onChangeText={this.tt.onPaginationInputChange}
-                onSubmitEditing={this.tt.onPaginationInputSubmit}
-                ref={this.tt.pageInputRef}
-                selectTextOnFocus
-                style={styles.paginationInputStyle ||= {
-                  border: 0,
-                  color: "#0f172a",
-                  fontSize: 12,
-                  outline: "none",
-                  padding: 0,
-                  textAlign: "center",
-                  width: 80
-                }}
-                value={this.s.pageInputValue}
-              />
-            }
-          </Pressable>
+            <TextInput
+              dataSet={dataSets.paginationInput ||= {class: "pagination-input"}}
+              keyboardType="number-pad"
+              onBlur={this.tt.onPaginationInputBlur}
+              onChangeText={this.tt.onPaginationInputChange}
+              onFocus={this.tt.onPaginationInputFocus}
+              onPressIn={this.tt.onPaginationInputFocus}
+              onKeyDown={this.tt.onPaginationInputKeyDown}
+              onSubmitEditing={this.tt.onPaginationInputSubmit}
+              ref={this.tt.pageInputRef}
+              selectTextOnFocus
+              style={styles.paginationInputStyle ||= {
+                border: 0,
+                color: "#0f172a",
+                fontSize: 12,
+                outline: "none",
+                padding: 0,
+                textAlign: "center",
+                width: 120
+              }}
+              value={this.s.pageInputValue}
+            />
+          </View>
           <Pressable
             dataSet={dataSets.paginationNextButton ||= {class: "pagination-next"}}
             disabled={nextDisabled}

--- a/src/select/index.jsx
+++ b/src/select/index.jsx
@@ -1004,6 +1004,13 @@ export default memo(shapeComponent(class HayaSelect extends ShapeComponent {
     event.stopPropagation?.()
 
     const totalPages = this.paginationTotalPages()
+    const nextPage = Number(this.s.pageInputValue)
+
+    if (totalPages && Number.isFinite(nextPage)) {
+      this.setPaginationPage(nextPage)
+      return
+    }
+
     const pageValue = totalPages ? `Page ${this.getActivePage()} of ${totalPages}` : String(this.getActivePage())
 
     this.setState({pageInputValue: pageValue})

--- a/src/select/index.jsx
+++ b/src/select/index.jsx
@@ -728,12 +728,15 @@ export default memo(shapeComponent(class HayaSelect extends ShapeComponent {
 
   onSearchTextInputChangedDebounced = debounce(this.tt.loadOptions, 200)
 
-  closeOptions() {
+  closeOptions({options} = {}) {
+    const closedOptions = options || this.getCurrentOptions()
+
     this.setState({
       height: null,
       loadedOptions: undefined,
       opened: false,
       optionsContainerLayout: null,
+      optionsVisibility: "hidden",
       page: 1,
       pageInputActive: false,
       pageInputValue: "",
@@ -742,7 +745,7 @@ export default memo(shapeComponent(class HayaSelect extends ShapeComponent {
     })
 
     if (this.props.onOptionsClosed) {
-      this.props.onOptionsClosed({options: this.getCurrentOptions()})
+      this.props.onOptionsClosed({options: closedOptions})
     }
 
     if (this.p.onBlur) this.p.onBlur()
@@ -1318,6 +1321,8 @@ export default memo(shapeComponent(class HayaSelect extends ShapeComponent {
 
     const options = newCurrentOptions || currentOptions
 
+    if (!multiple) this.closeOptions({options})
+
     if (onChange) {
       onChange({
         event,
@@ -1338,7 +1343,6 @@ export default memo(shapeComponent(class HayaSelect extends ShapeComponent {
       this.p.onChangeValue(optionValue)
     }
 
-    if (!multiple) this.closeOptions()
     this.setState(newState)
   }
 

--- a/src/select/index.jsx
+++ b/src/select/index.jsx
@@ -68,7 +68,8 @@ const paginationButtonStyles = {}
  * @property {function(import("react").SyntheticEvent=): void} [onChange]
  * @property {function(Array<string|number>=): void} [onChangeValue]
  * @property {function(import("react").SyntheticEvent=): void} [onFocus]
- * @property {function(): void} [onOptionsClosed]
+ * @property {function({options: Array}): void} [onOptionsClosed]
+ * @property {function({options: Array}): void} [onOptionsLoaded]
  * @property {function(object): import("react").ReactNode} [optionContent]
  * @property {Array<HayaSelectOption>|function(): (Array<HayaSelectOption>|HayaSelectOptionsResult)} options
  * @property {boolean} optionsAbsolute
@@ -184,6 +185,7 @@ export default memo(shapeComponent(class HayaSelect extends ShapeComponent {
     onChangeValue: PropTypes.func,
     onFocus: PropTypes.func,
     onOptionsClosed: PropTypes.func,
+    onOptionsLoaded: PropTypes.func,
     optionContent: PropTypes.func,
     options: PropTypes.oneOfType([
       PropTypes.arrayOf(PropTypes.shape({
@@ -657,7 +659,7 @@ export default memo(shapeComponent(class HayaSelect extends ShapeComponent {
       pageInputValue: totalPages ? `Page ${resolvedPage} of ${totalPages}` : String(resolvedPage),
       pageSize: Number.isFinite(totalCount) ? resolvedPageSize : null,
       totalCount: Number.isFinite(totalCount) ? totalCount : null
-    })
+    }, () => this.props.onOptionsLoaded?.({options: loadedOptions}))
   }
 
   hayaSelectOption({key, loadedOption}) {
@@ -1004,7 +1006,9 @@ export default memo(shapeComponent(class HayaSelect extends ShapeComponent {
     event.stopPropagation?.()
 
     const totalPages = this.paginationTotalPages()
-    const nextPage = Number(this.s.pageInputValue)
+    const rawValue = event?.target?.value ?? this.s.pageInputValue
+    const parsedValue = rawValue ? Number(String(rawValue).match(/\d+/)?.[0]) : NaN
+    const nextPage = Number.isFinite(parsedValue) ? parsedValue : Number(this.s.pageInputValue)
 
     if (totalPages && Number.isFinite(nextPage)) {
       this.setPaginationPage(nextPage)

--- a/src/system-test-helpers.js
+++ b/src/system-test-helpers.js
@@ -34,16 +34,25 @@ export default class HayaSelectSystemTestHelper {
 
     const selectContainer = await this.systemTest.find(this.selectContainerSelector)
     const driver = this.systemTest.getDriver()
-    await driver.executeScript(
-      "arguments[0].scrollIntoView({block: 'center', inline: 'center'})",
-      selectContainer
-    )
+    await driver.executeScript("arguments[0].scrollIntoView({block: 'center', inline: 'center'})", selectContainer)
     await this.systemTest.click(selectContainer)
-    await waitFor({timeout: 10000}, async () => {
-      if (!(await this.isOpen())) {
-        throw new Error("Options not visible yet")
-      }
-    })
+    try {
+      await waitFor({timeout: 2000}, async () => {
+        if (!(await this.isOpen())) {
+          throw new Error("Options not visible yet")
+        }
+      })
+    } catch (error) {
+      await driver.executeScript(
+        "arguments[0].dispatchEvent(new MouseEvent('click', {bubbles: true, cancelable: true}))",
+        selectContainer
+      )
+      await waitFor({timeout: 10000}, async () => {
+        if (!(await this.isOpen())) {
+          throw new Error("Options not visible yet")
+        }
+      })
+    }
     this._optionsContainerSelector = null
   }
 
@@ -51,16 +60,25 @@ export default class HayaSelectSystemTestHelper {
   async close() {
     const selectContainer = await this.systemTest.find(this.selectContainerSelector)
     const driver = this.systemTest.getDriver()
-    await driver.executeScript(
-      "arguments[0].scrollIntoView({block: 'center', inline: 'center'})",
-      selectContainer
-    )
+    await driver.executeScript("arguments[0].scrollIntoView({block: 'center', inline: 'center'})", selectContainer)
     await this.systemTest.click(selectContainer)
-    await waitFor({timeout: 5000}, async () => {
-      if (await this.isOpen()) {
-        throw new Error("Options are still visible")
-      }
-    })
+    try {
+      await waitFor({timeout: 2000}, async () => {
+        if (await this.isOpen()) {
+          throw new Error("Options are still visible")
+        }
+      })
+    } catch (error) {
+      await driver.executeScript(
+        "arguments[0].dispatchEvent(new MouseEvent('click', {bubbles: true, cancelable: true}))",
+        selectContainer
+      )
+      await waitFor({timeout: 5000}, async () => {
+        if (await this.isOpen()) {
+          throw new Error("Options are still visible")
+        }
+      })
+    }
   }
 
   /** @returns {Promise<boolean>} */
@@ -87,9 +105,7 @@ export default class HayaSelectSystemTestHelper {
 
     const id = elements.length > 0 ? await elements[0].getAttribute("data-id") : null
 
-    this._optionsContainerSelector = id
-      ? `[data-class='options-container'][data-id='${id}']`
-      : this.optionsContainerSelectorFallback
+    this._optionsContainerSelector = id ? `[data-class='options-container'][data-id='${id}']` : this.optionsContainerSelectorFallback
 
     return this._optionsContainerSelector
   }
@@ -120,10 +136,7 @@ export default class HayaSelectSystemTestHelper {
     if (typeof value != "undefined") {
       await waitFor({timeout: 5000}, async () => {
         const optionsContainerSelector = await this.optionsContainerSelector()
-        const option = await this.systemTest.find(
-          `${optionsContainerSelector} [data-class='select-option'][data-value='${value}']`,
-          {useBaseSelector: false}
-        )
+        const option = await this.systemTest.find(`${optionsContainerSelector} [data-class='select-option'][data-value='${value}']`, {useBaseSelector: false})
 
         await this.systemTest.click(option)
       })

--- a/src/system-test-helpers.js
+++ b/src/system-test-helpers.js
@@ -39,10 +39,7 @@ export default class HayaSelectSystemTestHelper {
       "arguments[0].scrollIntoView({block: 'center', inline: 'center'})",
       selectContainer
     )
-    await driver.executeScript(
-      "arguments[0].dispatchEvent(new MouseEvent('click', {bubbles: true, cancelable: true}))",
-      selectContainer
-    )
+    await this.systemTest.click(selectContainer)
     await waitFor({timeout: 10000}, async () => {
       const searchInputsAfterClick = await this.systemTest.all(this.searchInputSelector, {timeout: 0, visible: true})
 
@@ -55,7 +52,13 @@ export default class HayaSelectSystemTestHelper {
 
   /** @returns {Promise<void>} */
   async close() {
-    await this.systemTest.click(this.selectContainerSelector)
+    const selectContainer = await this.systemTest.find(this.selectContainerSelector)
+    const driver = this.systemTest.getDriver()
+    await driver.executeScript(
+      "arguments[0].scrollIntoView({block: 'center', inline: 'center'})",
+      selectContainer
+    )
+    await this.systemTest.click(selectContainer)
     await waitFor({timeout: 5000}, async () => {
       const searchInputs = await this.systemTest.all(this.searchInputSelector, {timeout: 0, visible: true})
 

--- a/src/system-test-helpers.js
+++ b/src/system-test-helpers.js
@@ -42,11 +42,8 @@ export default class HayaSelectSystemTestHelper {
           throw new Error("Options not visible yet")
         }
       })
-    } catch (error) {
-      await driver.executeScript(
-        "arguments[0].dispatchEvent(new MouseEvent('click', {bubbles: true, cancelable: true}))",
-        selectContainer
-      )
+    } catch (_error) {
+      await driver.executeScript("arguments[0].dispatchEvent(new MouseEvent('click', {bubbles: true, cancelable: true}))", selectContainer)
       await waitFor({timeout: 10000}, async () => {
         if (!(await this.isOpen())) {
           throw new Error("Options not visible yet")
@@ -68,11 +65,8 @@ export default class HayaSelectSystemTestHelper {
           throw new Error("Options are still visible")
         }
       })
-    } catch (error) {
-      await driver.executeScript(
-        "arguments[0].dispatchEvent(new MouseEvent('click', {bubbles: true, cancelable: true}))",
-        selectContainer
-      )
+    } catch (_error) {
+      await driver.executeScript("arguments[0].dispatchEvent(new MouseEvent('click', {bubbles: true, cancelable: true}))", selectContainer)
       await waitFor({timeout: 5000}, async () => {
         if (await this.isOpen()) {
           throw new Error("Options are still visible")
@@ -88,9 +82,13 @@ export default class HayaSelectSystemTestHelper {
 
     for (const option of options) {
       if (await option.isDisplayed()) return true
+      const visibility = await option.getCssValue("visibility")
+      if (visibility && visibility !== "hidden") return true
     }
 
-    return false
+    const searchInputs = await this.systemTest.all(this.searchInputSelector, {timeout: 0, visible: true})
+
+    return searchInputs.length > 0
   }
 
   /** @returns {Promise<string>} */

--- a/src/system-test-helpers.js
+++ b/src/system-test-helpers.js
@@ -68,7 +68,11 @@ export default class HayaSelectSystemTestHelper {
     const optionsContainerSelector = await this.optionsContainerSelector()
     const options = await this.systemTest.all(optionsContainerSelector, {timeout: 0, useBaseSelector: false})
 
-    return options.length > 0
+    for (const option of options) {
+      if (await option.isDisplayed()) return true
+    }
+
+    return false
   }
 
   /** @returns {Promise<string>} */

--- a/src/system-test-helpers.js
+++ b/src/system-test-helpers.js
@@ -51,7 +51,9 @@ export default class HayaSelectSystemTestHelper {
     const scoundrel = await this.systemTest.getScoundrelClient()
 
     return await scoundrel.evalResult(`
-      return Boolean(document.querySelector(${JSON.stringify(this.searchInputSelector)}))
+      (() => {
+        return Boolean(document.querySelector(${JSON.stringify(this.searchInputSelector)}))
+      })()
     `)
   }
 
@@ -61,10 +63,12 @@ export default class HayaSelectSystemTestHelper {
 
     const scoundrel = await this.systemTest.getScoundrelClient()
     const selector = await scoundrel.evalResult(`
-      const root = document.querySelector(${JSON.stringify(this.componentSelector)}) ||
-        document.querySelector(${JSON.stringify(this.rootSelector)})
-      const id = root?.dataset?.id
-      return id ? "[data-class='options-container'][data-id='" + id + "']" : null
+      (() => {
+        const root = document.querySelector(${JSON.stringify(this.componentSelector)}) ||
+          document.querySelector(${JSON.stringify(this.rootSelector)})
+        const id = root?.dataset?.id
+        return id ? "[data-class='options-container'][data-id='" + id + "']" : null
+      })()
     `)
 
     this._optionsContainerSelector = selector || "[data-class='options-container']"


### PR DESCRIPTION
## Problem
In Firefox, HayaSelect could leave the options portal visible after selecting an option when onChange triggered a re-render, causing system specs to fail.

## Solution
- Close options before firing onChange/onChangeValue for single selects and hide the portal on close.
- Add a system test and example case that re-renders on change to guard against the regression.
- Stabilize system-test eval helpers to avoid illegal return statements and reduce cross-test bleed in the multiple-select spec.
- Add ya-use-event-listener to the example app dependencies so dist builds resolve the hook.

## Testing
- `npm run test:dist`