### PR TITLE
Expose HayaSelect options visibility state for deterministic test waits

### DIFF
--- a/src/select/index.jsx
+++ b/src/select/index.jsx
@@ -1348,7 +1348,11 @@ export default memo(shapeComponent(class HayaSelect extends ShapeComponent {
 
     return (
       <View
-        dataSet={this.cache("optionsContainerDataSet", {class: "options-container", id, role: "dialog"}, [id])}
+        dataSet={this.cache(
+          "optionsContainerDataSet",
+          {class: "options-container", id, role: "dialog", optionsVisibility: optionsVisibility || "hidden"},
+          [id, optionsVisibility]
+        )}
         onLayout={this.tt.onOptionsContainerLayout}
         ref={this.tt.optionsContainerRef}
         style={style}


### PR DESCRIPTION
## Problem
System specs can attempt to select options while the options container is mounted but still hidden during open/positioning. On slower CI this creates a race where helpers find the container before options are visibly ready.

## Fix
- Added `data-options-visibility` on the options container.
- The attribute mirrors internal options visibility (`hidden` / `visible`) so tests can wait for explicit readiness.

## Testing
- `npm run lint`
- `npm run typecheck`
