### PR TITLE
Use awaitery wait in system test lifecycle and update agent notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,9 @@
 - Propose commit messages and PR titles/descriptions yourself unless explicitly provided.
 - If the example app server is not running locally, use `npm run test:dist` (which runs `npm run build:example:dist`) to build the example web `dist/` and run system tests.
 - System tests require `SYSTEM_TEST_HOST` set to `dist` or `expo-dev-server`; prefer `npm run test:dist` unless the Expo dev server is already running.
+- Keep `.github/dependabot.yml` update configs unique per `package-ecosystem` + `directory` + `target-branch`; do not duplicate `npm` entries for `/example`.
+- If `expo-doctor` reports Expo SDK support-package mismatches with unexpected nested newer Expo packages, run `npm dedupe` and re-run doctor before bumping SDK/deps.
+- Keep a stub `setUseTranslate` in the example app bootstrap for system tests so fallback translator warning logs do not pollute browser output.
 - Avoid ending JavaScript lines with semicolons unless required for correctness.
 - Use spaces inside named import/export braces (for example: `{foo, bar}`).
 - For scoundrel evals that return data, use an explicit `return` statement inside the eval.

--- a/spec/system/system-test-lifecycle.js
+++ b/spec/system/system-test-lifecycle.js
@@ -1,4 +1,5 @@
 import timeout from "awaitery/build/timeout.js"
+import wait from "awaitery/build/wait.js"
 import SystemTest from "system-testing/build/system-test.js"
 
 SystemTest.rootPath = "/?systemTest=true"
@@ -16,13 +17,6 @@ let runQueue = Promise.resolve()
 
 /** @param {unknown} error */
 const dismissToListenerMissingError = (error) => error instanceof Error && error.message.includes("No listener registered for command event: dismissTo")
-
-/** @returns {Promise<void>} */
-const sleep = async () => {
-  await new Promise((resolve) => {
-    setTimeout(resolve, 200)
-  })
-}
 
 /**
  * @param {import("system-testing/build/system-test.js").default} systemTest
@@ -56,7 +50,7 @@ export const runSystemTest = async (callback) => {
           throw error
         }
 
-        await sleep()
+        await wait(200)
       }
     }
   }


### PR DESCRIPTION
## Summary
- replace the local `sleep` helper in system test lifecycle with `awaitery`'s built-in `wait`
- update repo `AGENTS.md` with lessons learned from recent CI/debugging work (dependabot uniqueness, expo-doctor dedupe path, example translate stub guidance)

## Testing
- `npm run lint`
- `npm run typecheck`
