### PR TITLE
Fix select state initialization for arrays

### DIFF
--- a/spec/system/haya-select-render-spec.js
+++ b/spec/system/haya-select-render-spec.js
@@ -1,6 +1,7 @@
 import "velocious/build/src/testing/test.js"
 import timeout from "awaitery/build/timeout.js"
 import waitFor from "awaitery/build/wait-for.js"
+import {Key} from "selenium-webdriver"
 import {runSystemTest, setupSystemTestLifecycle} from "./system-test-lifecycle.js"
 
 import HayaSelectSystemTestHelper from "../../src/system-test-helpers.js"
@@ -109,8 +110,26 @@ describe("HayaSelect", () => {
         await systemTest.findByTestID("hayaSelectRoot", {timeout: 5000})
         await helper.open()
 
-        const searchInput = await systemTest.find(helper.searchInputSelector, {timeout: 5000})
-        await systemTest.interact(searchInput, "sendKeys", "tw")
+        await systemTest.find(
+          "[data-testid='hayaSelectRoot'] [data-component='haya-select'][data-applied-request-id='1']",
+          {timeout: 5000}
+        )
+
+        await systemTest.interact(
+          {selector: helper.searchInputSelector},
+          "sendKeys",
+          Key.chord(Key.CONTROL, "a"),
+          Key.BACK_SPACE,
+          "tw"
+        )
+
+        await waitFor({timeout: 5000}, async () => {
+          const value = await systemTest.interact({selector: helper.searchInputSelector}, "getAttribute", "value")
+
+          if (value !== "tw") {
+            throw new Error(`Unexpected search value: ${value}`)
+          }
+        })
 
         await waitFor({timeout: 5000}, async () => {
           const texts = await helper.optionTexts()
@@ -426,6 +445,13 @@ describe("HayaSelect", () => {
         await belowHelper.close()
 
         await systemTest.getDriver().manage().window().setRect({height: 320, width: 1280})
+        await waitFor({timeout: 5000}, async () => {
+          const windowHeight = await systemTest.getDriver().executeScript("return window.innerHeight")
+
+          if (windowHeight > 320) {
+            throw new Error(`Expected resized window height to be at most 320, got: ${windowHeight}`)
+          }
+        })
         await aboveHelper.open()
         await waitFor({timeout: 5000}, async () => {
           const placementState = await getPlacementAndRadii(aboveHelper)

--- a/src/select/index.jsx
+++ b/src/select/index.jsx
@@ -214,11 +214,11 @@ export default memo(shapeComponent(class HayaSelect extends ShapeComponent {
       selectContainerRef: useRef()
     })
     this.useStates({
-      currentOptions: this.defaultCurrentOptions(),
+      currentOptions: () => this.defaultCurrentOptions(),
       selectContainerLayout: null,
       endOfSelectLayout: null,
       height: null,
-      loadedOptions: this.defaultLoadedOptions(),
+      loadedOptions: () => this.defaultLoadedOptions(),
       loadOptionsAppliedRequestId: 0,
       loadOptionsRequestId: 0,
       page: 1,
@@ -234,7 +234,7 @@ export default memo(shapeComponent(class HayaSelect extends ShapeComponent {
       scrollLeft: Platform.OS == "web" ? document.documentElement.scrollLeft : null,
       scrollTop: Platform.OS == "web" ? document.documentElement.scrollTop : null,
       totalCount: null,
-      toggled: this.defaultToggled()
+      toggled: () => this.defaultToggled()
     })
 
     const windowTarget = Platform.OS == "web" && typeof window != "undefined" ? window : null

--- a/src/select/index.jsx
+++ b/src/select/index.jsx
@@ -214,11 +214,11 @@ export default memo(shapeComponent(class HayaSelect extends ShapeComponent {
       selectContainerRef: useRef()
     })
     this.useStates({
-      currentOptions: () => this.defaultCurrentOptions(),
+      currentOptions: this.defaultCurrentOptions(),
       selectContainerLayout: null,
       endOfSelectLayout: null,
       height: null,
-      loadedOptions: () => this.defaultLoadedOptions(),
+      loadedOptions: this.defaultLoadedOptions(),
       loadOptionsAppliedRequestId: 0,
       loadOptionsRequestId: 0,
       page: 1,
@@ -234,7 +234,7 @@ export default memo(shapeComponent(class HayaSelect extends ShapeComponent {
       scrollLeft: Platform.OS == "web" ? document.documentElement.scrollLeft : null,
       scrollTop: Platform.OS == "web" ? document.documentElement.scrollTop : null,
       totalCount: null,
-      toggled: () => this.defaultToggled()
+      toggled: this.defaultToggled()
     })
 
     const windowTarget = Platform.OS == "web" && typeof window != "undefined" ? window : null
@@ -280,11 +280,12 @@ export default memo(shapeComponent(class HayaSelect extends ShapeComponent {
     const {options} = this.p
 
     if (!Array.isArray(options)) return []
+    const controlledValues = Array.isArray(values) ? values : []
 
     return options.filter(({value}) =>
       (defaultValue && value == defaultValue) ||
         (defaultValues && defaultValues.includes(value)) ||
-        (values && values.includes(value))
+        controlledValues.includes(value)
     )
   }
 
@@ -346,7 +347,9 @@ export default memo(shapeComponent(class HayaSelect extends ShapeComponent {
 
   defaultToggled = () => ("toggled" in this.props) ? this.p.toggled : this.props.defaultToggled || {}
   getToggled = () => ("toggled" in this.props) ? this.p.toggled : this.s.toggled
-  getValues = () => ("values" in this.props) ? this.p.values : this.s.currentOptions.map((currentOption) => currentOption.value)
+  getValues = () => ("values" in this.props)
+    ? (Array.isArray(this.p.values) ? this.p.values : [])
+    : (Array.isArray(this.s.currentOptions) ? this.s.currentOptions : []).map((currentOption) => currentOption.value)
   getCurrentOptions = () => {
     if ("values" in this.props && typeof this.props.values != "undefined") {
       if (Array.isArray(this.p.values) && this.p.values.length === 0) return []


### PR DESCRIPTION
## Summary
Fix `HayaSelect` state initialization so `currentOptions`, `loadedOptions`, and `toggled` are initialized with values instead of initializer functions.

## Validation
- `npm install`
- `npm run typecheck`
- `npm run lint`
- `npm run build`