### PR TITLE
[codex] Refactor HayaSelect state typing and bump set-state-compare

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -25,7 +25,7 @@
         "react-native-render-html": "^6.3.4",
         "react-native-vector-icons": "^10.2.0",
         "react-native-web": "~0.19.13",
-        "set-state-compare": "^1.0.72",
+        "set-state-compare": "^1.0.83",
         "ya-use-event-listener": "^0.1.1"
       },
       "devDependencies": {
@@ -35,7 +35,7 @@
       }
     },
     "..": {
-      "version": "1.0.100",
+      "version": "1.0.102",
       "license": "MIT",
       "dependencies": {
         "awaitery": "^1.0.13",
@@ -53,9 +53,9 @@
         "expo-module-scripts": "^4.0.2",
         "react": "18.3.1",
         "react-native": "0.76.9",
-        "scoundrel-remote-eval": "1.0.31",
+        "scoundrel-remote-eval": "1.0.33",
         "sqlite": "^5.1.1",
-        "sqlite3": "^5.1.7",
+        "sqlite3": "^6.0.1",
         "system-testing": "^1.0.75",
         "velocious": "^1.0.176"
       },
@@ -67,7 +67,7 @@
         "prop-types": "*",
         "react": "*",
         "react-native": "*",
-        "set-state-compare": ">= 1.0.72"
+        "set-state-compare": ">= 1.0.83"
       }
     },
     "node_modules/@0no-co/graphql.web": {
@@ -6210,9 +6210,9 @@
       "license": "MIT"
     },
     "node_modules/fetching-object": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/fetching-object/-/fetching-object-1.0.5.tgz",
-      "integrity": "sha512-hXflbW3DknOZJdqduLZn/hiMWDO9/eEv2BMvc8F8BO/3Fbh0B7hMrcaKdlQolJw3To3SJD1l9yzsCmWtzsmlpw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/fetching-object/-/fetching-object-1.0.7.tgz",
+      "integrity": "sha512-DVBXLz6EijDqntTWpw/4m/77yFfPXGUVrcTI0fQXJWS9Zu7ljgKVhIi7NI+jrcqBxsJFpN+vM7spyX2JGKEiAA==",
       "license": "ISC"
     },
     "node_modules/file-saver": {
@@ -10502,13 +10502,13 @@
       }
     },
     "node_modules/set-state-compare": {
-      "version": "1.0.72",
-      "resolved": "https://registry.npmjs.org/set-state-compare/-/set-state-compare-1.0.72.tgz",
-      "integrity": "sha512-vMP/1NZEBPb7mFwlgiULwHegIG9hUxW3iZzY8kW4GR7zVFM1KVS/1bHA/5xW21tQBRQyJjyP6e9AfsACGwLrHQ==",
+      "version": "1.0.83",
+      "resolved": "https://registry.npmjs.org/set-state-compare/-/set-state-compare-1.0.83.tgz",
+      "integrity": "sha512-oAIaYX6zcWloYcoXSx8wAGRj0qj3MGoYcmwj4oIKQq4/TgVAO9gWqjFCXI2BXJvBP7/qzLV6J6ZFVfQPOwbokw==",
       "license": "ISC",
       "dependencies": {
         "diggerize": "^1.0.5",
-        "fetching-object": ">= 1.0.5"
+        "fetching-object": "^1.0.7"
       },
       "peerDependencies": {
         "prop-types": ">= 15.8.1",

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -11,7 +11,7 @@
         "@expo/metro-runtime": "~4.0.1",
         "@kaspernj/api-maker": "1.0.2100",
         "classnames": "^2.3.1",
-        "conjointment": "^0.1.9",
+        "conjointment": "^0.1.11",
         "debounce": "^2.1.0",
         "diggerize": "^1.0.4",
         "expo": "~52.0.49",
@@ -61,7 +61,7 @@
       },
       "peerDependencies": {
         "@kaspernj/api-maker": ">= 1.0.2100",
-        "conjointment": "^0.1.9",
+        "conjointment": "^0.1.11",
         "expo": "*",
         "outside-eye": "*",
         "prop-types": "*",
@@ -5189,19 +5189,19 @@
       "license": "MIT"
     },
     "node_modules/conjointment": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/conjointment/-/conjointment-0.1.9.tgz",
-      "integrity": "sha512-q6c7AOvBhjLns95ZKCn/FkvSAr4LYYEuAahYxoG+ih8cF4GWkcCl/pgg+UBdFc2YOkP1XOGjxVozB3k8fObqrQ==",
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/conjointment/-/conjointment-0.1.11.tgz",
+      "integrity": "sha512-H1S2xTe7qUe9WTiingIoHweSVG/QK+Bkwhi3rpn9ihssoYtIjQMJiwkAl8cinAmBzTnt7j06GSACjR6m0jkoMQ==",
       "license": "MIT",
       "dependencies": {
         "prop-types": "^15.8.1",
-        "prop-types-exact": "^1.2.5",
-        "set-state-compare": "^1.0.61"
+        "prop-types-exact": "^1.2.5"
       },
       "peerDependencies": {
         "expo": "*",
         "react": "*",
-        "react-native": "*"
+        "react-native": "*",
+        "set-state-compare": ">= 1.0.83"
       }
     },
     "node_modules/connect": {

--- a/example/package.json
+++ b/example/package.json
@@ -26,7 +26,7 @@
     "react-native-render-html": "^6.3.4",
     "react-native-vector-icons": "^10.2.0",
     "react-native-web": "~0.19.13",
-    "set-state-compare": "^1.0.72",
+    "set-state-compare": "^1.0.83",
     "ya-use-event-listener": "^0.1.1"
   },
   "devDependencies": {

--- a/example/package.json
+++ b/example/package.json
@@ -12,7 +12,7 @@
     "@kaspernj/api-maker": "1.0.2100",
     "@expo/metro-runtime": "~4.0.1",
     "classnames": "^2.3.1",
-    "conjointment": "^0.1.9",
+    "conjointment": "^0.1.11",
     "debounce": "^2.1.0",
     "diggerize": "^1.0.4",
     "expo": "~52.0.49",

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
       },
       "peerDependencies": {
         "@kaspernj/api-maker": ">= 1.0.2100",
-        "conjointment": "^0.1.9",
+        "conjointment": "^0.1.11",
         "expo": "*",
         "outside-eye": "*",
         "prop-types": "*",
@@ -8675,20 +8675,20 @@
       "license": "MIT"
     },
     "node_modules/conjointment": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/conjointment/-/conjointment-0.1.9.tgz",
-      "integrity": "sha512-q6c7AOvBhjLns95ZKCn/FkvSAr4LYYEuAahYxoG+ih8cF4GWkcCl/pgg+UBdFc2YOkP1XOGjxVozB3k8fObqrQ==",
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/conjointment/-/conjointment-0.1.11.tgz",
+      "integrity": "sha512-H1S2xTe7qUe9WTiingIoHweSVG/QK+Bkwhi3rpn9ihssoYtIjQMJiwkAl8cinAmBzTnt7j06GSACjR6m0jkoMQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "prop-types": "^15.8.1",
-        "prop-types-exact": "^1.2.5",
-        "set-state-compare": "^1.0.61"
+        "prop-types-exact": "^1.2.5"
       },
       "peerDependencies": {
         "expo": "*",
         "react": "*",
-        "react-native": "*"
+        "react-native": "*",
+        "set-state-compare": ">= 1.0.83"
       }
     },
     "node_modules/connect": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,9 +24,9 @@
         "expo-module-scripts": "^4.0.2",
         "react": "18.3.1",
         "react-native": "0.76.9",
-        "scoundrel-remote-eval": "1.0.31",
+        "scoundrel-remote-eval": "1.0.33",
         "sqlite": "^5.1.1",
-        "sqlite3": "^5.1.7",
+        "sqlite3": "^6.0.1",
         "system-testing": "^1.0.75",
         "velocious": "^1.0.176"
       },
@@ -38,7 +38,7 @@
         "prop-types": "*",
         "react": "*",
         "react-native": "*",
-        "set-state-compare": ">= 1.0.72"
+        "set-state-compare": ">= 1.0.83"
       }
     },
     "node_modules/@0no-co/graphql.web": {
@@ -3729,13 +3729,16 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/@gar/promisify": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
-      "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
+    "node_modules/@gar/promise-retry": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@gar/promise-retry/-/promise-retry-1.0.3.tgz",
+      "integrity": "sha512-GmzA9ckNokPypTg10pgpeHNQe7ph+iIKKmhKu3Ob9ANkswreCx7R3cKmY781K8QK3AqVL3xVh9A42JvIAbkkSA==",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
@@ -4340,6 +4343,19 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@isaacs/ttlcache": {
@@ -4955,6 +4971,76 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@npmcli/agent": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-4.0.0.tgz",
+      "integrity": "sha512-kAQTcEN9E8ERLVg5AsGwLNoFb+oEG6engbqAU2P43gD4JEIkNGMHdVQ096FsOAAYpZPB0RSt0zgInKIAS1l5QA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.1",
+        "lru-cache": "^11.2.1",
+        "socks-proxy-agent": "^8.0.3"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/agent/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@npmcli/agent/node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@npmcli/agent/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@npmcli/agent/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/@npmcli/fs": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-3.1.1.tgz",
@@ -4967,34 +5053,15 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
-    "node_modules/@npmcli/move-file": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz",
-      "integrity": "sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==",
-      "deprecated": "This functionality has been moved to @npmcli/fs",
+    "node_modules/@npmcli/redact": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/redact/-/redact-4.0.0.tgz",
+      "integrity": "sha512-gOBg5YHMfZy+TfHArfVogwgfBeQnKbbGo3pSUyK/gSI0AVu+pEiDVcKlQb0D8Mg1LNRZILZ6XG8I5dJ4KuAd9Q==",
       "dev": true,
-      "license": "MIT",
+      "license": "ISC",
       "optional": true,
-      "dependencies": {
-        "mkdirp": "^1.0.4",
-        "rimraf": "^3.0.2"
-      },
       "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@npmcli/move-file/node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -6210,12 +6277,15 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/abbrev": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-4.0.0.tgz",
+      "integrity": "sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==",
       "dev": true,
       "license": "ISC",
-      "optional": true
+      "optional": true,
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
@@ -6326,20 +6396,6 @@
       },
       "engines": {
         "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/agentkeepalive": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
-      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "humanize-ms": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
       }
     },
     "node_modules/aggregate-error": {
@@ -6752,14 +6808,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/aproba": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.1.0.tgz",
-      "integrity": "sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true
-    },
     "node_modules/archiver": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/archiver/-/archiver-7.0.1.tgz",
@@ -6935,38 +6983,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/are-we-there-yet": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
-      "integrity": "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==",
-      "deprecated": "This package is no longer supported.",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/are-we-there-yet/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/arg": {
@@ -8447,17 +8463,6 @@
         "node": ">=12.20"
       }
     },
-    "node_modules/color-support": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "bin": {
-        "color-support": "bin.js"
-      }
-    },
     "node_modules/color/node_modules/color-convert": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.3.tgz",
@@ -9311,14 +9316,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/delegates": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -9616,16 +9613,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
-      }
-    },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
@@ -9694,14 +9681,6 @@
       "resolved": "https://registry.npmjs.org/epic-locks/-/epic-locks-1.0.7.tgz",
       "integrity": "sha512-zAxc3RL3Mx1TH5G9uEy//UBDCzP9MC6H4kx8Mjt8sPmGfjXFU286u8jwm5rOQMe0X7v60BGP8uMlYKZXPJRTiQ==",
       "license": "ISC"
-    },
-    "node_modules/err-code": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
-      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
@@ -11323,6 +11302,25 @@
       "integrity": "sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ==",
       "license": "MIT"
     },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fecha": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
@@ -11337,9 +11335,9 @@
       "license": "MIT"
     },
     "node_modules/fetching-object": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/fetching-object/-/fetching-object-1.0.5.tgz",
-      "integrity": "sha512-hXflbW3DknOZJdqduLZn/hiMWDO9/eEv2BMvc8F8BO/3Fbh0B7hMrcaKdlQolJw3To3SJD1l9yzsCmWtzsmlpw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/fetching-object/-/fetching-object-1.0.7.tgz",
+      "integrity": "sha512-DVBXLz6EijDqntTWpw/4m/77yFfPXGUVrcTI0fQXJWS9Zu7ljgKVhIi7NI+jrcqBxsJFpN+vM7spyX2JGKEiAA==",
       "license": "ISC"
     },
     "node_modules/file-entry-cache": {
@@ -11889,60 +11887,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/gauge": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
-      "integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
-      "deprecated": "This package is no longer supported.",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "aproba": "^1.0.3 || ^2.0.0",
-        "color-support": "^1.1.3",
-        "console-control-strings": "^1.1.0",
-        "has-unicode": "^2.0.1",
-        "signal-exit": "^3.0.7",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1",
-        "wide-align": "^1.1.5"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/gauge/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/gauge/node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true
-    },
-    "node_modules/gauge/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -12298,14 +12242,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/has-unicode": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true
-    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -12541,17 +12477,6 @@
         "node": ">=10.17.0"
       }
     },
-    "node_modules/humanize-ms": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "ms": "^2.0.0"
-      }
-    },
     "node_modules/i18n-on-steroids": {
       "version": "1.0.21",
       "resolved": "https://registry.npmjs.org/i18n-on-steroids/-/i18n-on-steroids-1.0.21.tgz",
@@ -12568,7 +12493,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -12715,14 +12640,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/infer-owner": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
-      "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true
     },
     "node_modules/inflection": {
       "version": "3.0.2",
@@ -13090,14 +13007,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/is-lambda": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
-      "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/is-map": {
       "version": "2.0.3",
@@ -15455,240 +15364,206 @@
       "license": "ISC"
     },
     "node_modules/make-fetch-happen": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz",
-      "integrity": "sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==",
+      "version": "15.0.5",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-15.0.5.tgz",
+      "integrity": "sha512-uCbIa8jWWmQZt4dSnEStkVC6gdakiinAm4PiGsywIkguF0eWMdcjDz0ECYhUolFU3pFLOev9VNPCEygydXnddg==",
       "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
-        "agentkeepalive": "^4.1.3",
-        "cacache": "^15.2.0",
-        "http-cache-semantics": "^4.1.0",
-        "http-proxy-agent": "^4.0.1",
-        "https-proxy-agent": "^5.0.0",
-        "is-lambda": "^1.0.1",
-        "lru-cache": "^6.0.0",
-        "minipass": "^3.1.3",
-        "minipass-collect": "^1.0.2",
-        "minipass-fetch": "^1.3.2",
+        "@gar/promise-retry": "^1.0.0",
+        "@npmcli/agent": "^4.0.0",
+        "@npmcli/redact": "^4.0.0",
+        "cacache": "^20.0.1",
+        "http-cache-semantics": "^4.1.1",
+        "minipass": "^7.0.2",
+        "minipass-fetch": "^5.0.0",
         "minipass-flush": "^1.0.5",
         "minipass-pipeline": "^1.2.4",
-        "negotiator": "^0.6.2",
-        "promise-retry": "^2.0.1",
-        "socks-proxy-agent": "^6.0.0",
-        "ssri": "^8.0.0"
+        "negotiator": "^1.0.0",
+        "proc-log": "^6.0.0",
+        "ssri": "^13.0.0"
       },
       "engines": {
-        "node": ">= 10"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/make-fetch-happen/node_modules/@npmcli/fs": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-1.1.1.tgz",
-      "integrity": "sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-5.0.0.tgz",
+      "integrity": "sha512-7OsC1gNORBEawOa5+j2pXN9vsicaIOH5cPXxoR6fJOmH6/EXpJB2CajXOu1fPRFun2m1lktEFX11+P89hqO/og==",
       "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
-        "@gar/promisify": "^1.0.1",
         "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/make-fetch-happen/node_modules/@tootallnate/once": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
-      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+    "node_modules/make-fetch-happen/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
-        "node": ">= 6"
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/make-fetch-happen/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/make-fetch-happen/node_modules/cacache": {
-      "version": "15.3.0",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-15.3.0.tgz",
-      "integrity": "sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==",
+      "version": "20.0.4",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-20.0.4.tgz",
+      "integrity": "sha512-M3Lab8NPYlZU2exsL3bMVvMrMqgwCnMWfdZbK28bn3pK6APT/Te/I8hjRPNu1uwORY9a1eEQoifXbKPQMfMTOA==",
       "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
-        "@npmcli/fs": "^1.0.0",
-        "@npmcli/move-file": "^1.0.1",
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "glob": "^7.1.4",
-        "infer-owner": "^1.0.4",
-        "lru-cache": "^6.0.0",
-        "minipass": "^3.1.1",
-        "minipass-collect": "^1.0.2",
+        "@npmcli/fs": "^5.0.0",
+        "fs-minipass": "^3.0.0",
+        "glob": "^13.0.0",
+        "lru-cache": "^11.1.0",
+        "minipass": "^7.0.3",
+        "minipass-collect": "^2.0.1",
         "minipass-flush": "^1.0.5",
-        "minipass-pipeline": "^1.2.2",
-        "mkdirp": "^1.0.3",
-        "p-map": "^4.0.0",
-        "promise-inflight": "^1.0.1",
-        "rimraf": "^3.0.2",
-        "ssri": "^8.0.1",
-        "tar": "^6.0.2",
-        "unique-filename": "^1.1.1"
+        "minipass-pipeline": "^1.2.4",
+        "p-map": "^7.0.2",
+        "ssri": "^13.0.0"
       },
       "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/make-fetch-happen/node_modules/fs-minipass": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/make-fetch-happen/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "optional": true,
       "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
       },
       "engines": {
-        "node": "*"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/make-fetch-happen/node_modules/http-proxy-agent": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
-      "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@tootallnate/once": "1",
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/make-fetch-happen/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "optional": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
       "engines": {
-        "node": ">=10"
+        "node": "20 || >=22"
       }
     },
-    "node_modules/make-fetch-happen/node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+    "node_modules/make-fetch-happen/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "optional": true,
       "dependencies": {
-        "yallist": "^4.0.0"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/make-fetch-happen/node_modules/minipass-collect": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
-      "integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "minipass": "^3.0.0"
+        "node": "18 || 20 || >=22"
       },
-      "engines": {
-        "node": ">= 8"
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/make-fetch-happen/node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+    "node_modules/make-fetch-happen/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "bin": {
-        "mkdirp": "bin/cmd.js"
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/make-fetch-happen/node_modules/p-map": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
+      "integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-fetch-happen/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
       },
       "engines": {
-        "node": ">=10"
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/make-fetch-happen/node_modules/proc-log": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+      "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/make-fetch-happen/node_modules/ssri": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
-      "integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-13.0.1.tgz",
+      "integrity": "sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ==",
       "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
-        "minipass": "^3.1.1"
+        "minipass": "^7.0.3"
       },
       "engines": {
-        "node": ">= 8"
+        "node": "^20.17.0 || >=22.9.0"
       }
-    },
-    "node_modules/make-fetch-happen/node_modules/unique-filename": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
-      "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "unique-slug": "^2.0.0"
-      }
-    },
-    "node_modules/make-fetch-happen/node_modules/unique-slug": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
-      "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "imurmurhash": "^0.1.4"
-      }
-    },
-    "node_modules/make-fetch-happen/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
@@ -16373,45 +16248,55 @@
       }
     },
     "node_modules/minipass-fetch": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.4.1.tgz",
-      "integrity": "sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-5.0.2.tgz",
+      "integrity": "sha512-2d0q2a8eCi2IRg/IGubCNRJoYbA1+YPXAzQVRFmB45gdGZafyivnZ5YSEfo3JikbjGxOdntGFvBQGqaSMXlAFQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "minipass": "^3.1.0",
-        "minipass-sized": "^1.0.3",
-        "minizlib": "^2.0.0"
+        "minipass": "^7.0.3",
+        "minipass-sized": "^2.0.0",
+        "minizlib": "^3.0.1"
       },
       "engines": {
-        "node": ">=8"
+        "node": "^20.17.0 || >=22.9.0"
       },
       "optionalDependencies": {
-        "encoding": "^0.1.12"
+        "iconv-lite": "^0.7.2"
       }
     },
-    "node_modules/minipass-fetch/node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+    "node_modules/minipass-fetch/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
       "dev": true,
-      "license": "ISC",
+      "license": "MIT",
       "optional": true,
       "dependencies": {
-        "yallist": "^4.0.0"
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/minipass-fetch/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+    "node_modules/minipass-fetch/node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
       "dev": true,
-      "license": "ISC",
-      "optional": true
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
     },
     "node_modules/minipass-flush": {
       "version": "1.0.5",
@@ -16474,40 +16359,18 @@
       "license": "ISC"
     },
     "node_modules/minipass-sized": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
-      "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-2.0.0.tgz",
+      "integrity": "sha512-zSsHhto5BcUVM2m1LurnXY6M//cGhVaegT71OfOXoprxT6o780GZd792ea6FfrQkuU4usHZIUczAQMRUE2plzA==",
       "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
-        "minipass": "^3.0.0"
+        "minipass": "^7.1.2"
       },
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/minipass-sized/node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/minipass-sized/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true
     },
     "node_modules/minizlib": {
       "version": "2.1.2",
@@ -16703,11 +16566,14 @@
       }
     },
     "node_modules/node-addon-api": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
-      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.7.0.tgz",
+      "integrity": "sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
     },
     "node_modules/node-dir": {
       "version": "0.1.17",
@@ -16802,52 +16668,122 @@
       }
     },
     "node_modules/node-gyp": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-8.4.1.tgz",
-      "integrity": "sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==",
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-12.2.0.tgz",
+      "integrity": "sha512-q23WdzrQv48KozXlr0U1v9dwO/k59NHeSzn6loGcasyf0UnSrtzs8kRxM+mfwJSf0DkX0s43hcqgnSO4/VNthQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "env-paths": "^2.2.0",
-        "glob": "^7.1.4",
+        "exponential-backoff": "^3.1.1",
         "graceful-fs": "^4.2.6",
-        "make-fetch-happen": "^9.1.0",
-        "nopt": "^5.0.0",
-        "npmlog": "^6.0.0",
-        "rimraf": "^3.0.2",
+        "make-fetch-happen": "^15.0.0",
+        "nopt": "^9.0.0",
+        "proc-log": "^6.0.0",
         "semver": "^7.3.5",
-        "tar": "^6.1.2",
-        "which": "^2.0.2"
+        "tar": "^7.5.4",
+        "tinyglobby": "^0.2.12",
+        "which": "^6.0.0"
       },
       "bin": {
         "node-gyp": "bin/node-gyp.js"
       },
       "engines": {
-        "node": ">= 10.12.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/node-gyp/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
+    "node_modules/node-gyp/node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/node-gyp/node_modules/isexe": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+      "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/node-gyp/node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/node-gyp/node_modules/proc-log": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+      "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/node-gyp/node_modules/tar": {
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
+      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/node-gyp/node_modules/which": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+      "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
       "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "isexe": "^4.0.0"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
       },
       "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/node-gyp/node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/node-int64": {
@@ -16863,20 +16799,20 @@
       "license": "MIT"
     },
     "node_modules/nopt": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
-      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-9.0.0.tgz",
+      "integrity": "sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==",
       "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
-        "abbrev": "1"
+        "abbrev": "^4.0.0"
       },
       "bin": {
         "nopt": "bin/nopt.js"
       },
       "engines": {
-        "node": ">=6"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/normalize-package-data": {
@@ -16960,24 +16896,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/npmlog": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
-      "integrity": "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==",
-      "deprecated": "This package is no longer supported.",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "are-we-there-yet": "^3.0.0",
-        "console-control-strings": "^1.1.0",
-        "gauge": "^4.0.3",
-        "set-blocking": "^2.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/nullthrows": {
@@ -18056,29 +17974,6 @@
       "license": "MIT",
       "dependencies": {
         "asap": "~2.0.3"
-      }
-    },
-    "node_modules/promise-inflight": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
-      "integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true
-    },
-    "node_modules/promise-retry": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
-      "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "err-code": "^2.0.2",
-        "retry": "^0.12.0"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/prompts": {
@@ -19169,17 +19064,6 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
     },
-    "node_modules/retry": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -19355,7 +19239,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/sanitize-filename": {
@@ -19458,9 +19342,9 @@
       "peer": true
     },
     "node_modules/scoundrel-remote-eval": {
-      "version": "1.0.31",
-      "resolved": "https://registry.npmjs.org/scoundrel-remote-eval/-/scoundrel-remote-eval-1.0.31.tgz",
-      "integrity": "sha512-juufuCrBLmW10gkNr1Z6bu5jpxc0+2aP1h8yMTmT+IU4b5OjSj7QPJNJeMGE6x6EOMDGiN2UXzBHr8ipOL1txg==",
+      "version": "1.0.33",
+      "resolved": "https://registry.npmjs.org/scoundrel-remote-eval/-/scoundrel-remote-eval-1.0.33.tgz",
+      "integrity": "sha512-rIGO+Hwg78Aw7yf7O+hXNCk5GFDvJI9bIyRh2R7jiJgQ9HrdBjj3D2MLsKp/B04jarAiaX3ciGCjufFsdHlLrw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -19720,13 +19604,13 @@
       }
     },
     "node_modules/set-state-compare": {
-      "version": "1.0.72",
-      "resolved": "https://registry.npmjs.org/set-state-compare/-/set-state-compare-1.0.72.tgz",
-      "integrity": "sha512-vMP/1NZEBPb7mFwlgiULwHegIG9hUxW3iZzY8kW4GR7zVFM1KVS/1bHA/5xW21tQBRQyJjyP6e9AfsACGwLrHQ==",
+      "version": "1.0.83",
+      "resolved": "https://registry.npmjs.org/set-state-compare/-/set-state-compare-1.0.83.tgz",
+      "integrity": "sha512-oAIaYX6zcWloYcoXSx8wAGRj0qj3MGoYcmwj4oIKQq4/TgVAO9gWqjFCXI2BXJvBP7/qzLV6J6ZFVfQPOwbokw==",
       "license": "ISC",
       "dependencies": {
         "diggerize": "^1.0.5",
-        "fetching-object": ">= 1.0.5"
+        "fetching-object": "^1.0.7"
       },
       "peerDependencies": {
         "prop-types": ">= 15.8.1",
@@ -20063,19 +19947,30 @@
       }
     },
     "node_modules/socks-proxy-agent": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.2.1.tgz",
-      "integrity": "sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ==",
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "agent-base": "^6.0.2",
-        "debug": "^4.3.3",
-        "socks": "^2.6.2"
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
       },
       "engines": {
-        "node": ">= 10"
+        "node": ">= 14"
+      }
+    },
+    "node_modules/socks-proxy-agent/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/source-map": {
@@ -20238,28 +20133,81 @@
       "license": "MIT"
     },
     "node_modules/sqlite3": {
-      "version": "5.1.7",
-      "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-5.1.7.tgz",
-      "integrity": "sha512-GGIyOiFaG+TUra3JIfkI/zGP8yZYLPQ0pl1bH+ODjiX57sPhrLU5sQJn1y9bDKZUFYkX1crlrPfSYt0BKKdkog==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-6.0.1.tgz",
+      "integrity": "sha512-X0czUUMG2tmSqJpEQa3tCuZSHKIx8PwM53vLZzKp/o6Rpy25fiVfjdbnZ988M8+O3ZWR1ih0K255VumCb3MAnQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "bindings": "^1.5.0",
-        "node-addon-api": "^7.0.0",
-        "prebuild-install": "^7.1.1",
-        "tar": "^6.1.11"
+        "node-addon-api": "^8.0.0",
+        "prebuild-install": "^7.1.3",
+        "tar": "^7.5.10"
+      },
+      "engines": {
+        "node": ">=20.17.0"
       },
       "optionalDependencies": {
-        "node-gyp": "8.x"
+        "node-gyp": "12.x"
       },
       "peerDependencies": {
-        "node-gyp": "8.x"
+        "node-gyp": "12.x"
       },
       "peerDependenciesMeta": {
         "node-gyp": {
           "optional": true
         }
+      }
+    },
+    "node_modules/sqlite3/node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/sqlite3/node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/sqlite3/node_modules/tar": {
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
+      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/sqlite3/node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/ssri": {
@@ -21321,6 +21269,38 @@
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/tmp": {
       "version": "0.2.5",
@@ -22593,41 +22573,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/wide-align": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
-      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "string-width": "^1.0.2 || 2 || 3 || 4"
-      }
-    },
-    "node_modules/wide-align/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/wide-align/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/winston": {

--- a/package.json
+++ b/package.json
@@ -9,12 +9,12 @@
   "types": "build/index.d.ts",
   "scripts": {
     "build": "expo-module build",
-    "build:example:dist": "EXPO_NONINTERACTIVE=1 cd example && npx expo export --platform web --output-dir ../dist",
+    "build:example:dist": "npm run build && EXPO_NONINTERACTIVE=1 cd example && npx expo export --platform web --output-dir ../dist",
     "clean": "expo-module clean",
     "lint": "expo-module lint",
     "test": "node scripts/velocious-test.js",
     "test:dist": "npm run build:example:dist && SYSTEM_TEST_HOST=dist npm test",
-    "prepare": "expo-module prepare",
+    "prepare": "expo-module prepare && npm run build",
     "release:patch": "npm version patch -m \"Bump version to %s\" && git push --follow-tags && npm whoami || npm login && npm publish",
     "prepublishOnly": "expo-module prepublishOnly",
     "open:ios": "xed example/ios",
@@ -58,7 +58,7 @@
   },
   "peerDependencies": {
     "@kaspernj/api-maker": ">= 1.0.2100",
-    "conjointment": "^0.1.9",
+    "conjointment": "^0.1.11",
     "expo": "*",
     "outside-eye": "*",
     "prop-types": "*",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "prop-types": "*",
     "react": "*",
     "react-native": "*",
-    "set-state-compare": ">= 1.0.72"
+    "set-state-compare": ">= 1.0.83"
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/src/select/index.jsx
+++ b/src/select/index.jsx
@@ -2,7 +2,7 @@ import {anythingDifferent} from "set-state-compare/build/diff-utils"
 import Config from "../config.js"
 import {dig,digg} from "diggerize"
 import {Dimensions,Platform,Pressable,TextInput,View} from "react-native"
-import React,{memo,useEffect,useRef} from "react"
+import React,{createRef,memo,useEffect} from "react"
 import {shapeComponent,ShapeComponent} from "set-state-compare/build/shape-component.js"
 import debounce from "debounce"
 import FontAwesomeIcon from "react-native-vector-icons/FontAwesome"
@@ -86,6 +86,31 @@ const dataSets = {}
  * @property {Array<string|number>} [values]
  */
 
+/**
+ * @typedef {object} HayaSelectState
+ * @property {Array<HayaSelectOption>} currentOptions
+ * @property {object|null} selectContainerLayout
+ * @property {object|null} endOfSelectLayout
+ * @property {number|null} height
+ * @property {Array<HayaSelectOption>|undefined} loadedOptions
+ * @property {number} loadOptionsAppliedRequestId
+ * @property {number} loadOptionsRequestId
+ * @property {number} page
+ * @property {boolean} pageInputFocused
+ * @property {string} pageInputValue
+ * @property {number|null} pageSize
+ * @property {boolean} opened
+ * @property {object|null} optionsContainerLayout
+ * @property {"above"|"below"|undefined} optionsPlacement
+ * @property {number|undefined} optionsTop
+ * @property {"hidden"|"visible"|undefined} optionsVisibility
+ * @property {number|undefined|null} optionsWidth
+ * @property {number|null} scrollLeft
+ * @property {number|null} scrollTop
+ * @property {number|null} totalCount
+ * @property {Record<string|number, string>} toggled
+ */
+
 /** @returns {string} */
 const nameForComponentWithMultiple = (component) => {
   let name = nameForComponent(component)
@@ -102,8 +127,8 @@ const nameForComponentWithMultiple = (component) => {
   return name
 }
 
-/** @extends {ShapeComponent<HayaSelectProps>} */
-export default memo(shapeComponent(class HayaSelect extends ShapeComponent {
+/** @augments {ShapeComponent<HayaSelectProps, HayaSelectState>} */
+class HayaSelect extends ShapeComponent {
   static defaultProps = {
     debug: false,
     multiple: false,
@@ -168,11 +193,40 @@ export default memo(shapeComponent(class HayaSelect extends ShapeComponent {
   })
 
   callOptionsPositionAboveIfOutsideScreen = false
+  endOfSelectRef = createRef()
   latestLoadOptionsRequestId = 0
+  optionsContainerRef = createRef()
+  pageInputRef = createRef()
   searchTextValue = ""
+  searchTextInputRef = createRef()
+  selectContainerRef = createRef()
   t = Config.current().getUseTranslate()().t
   windowWidth = Dimensions.get("window").width
   windowHeight = Dimensions.get("window").height
+  /** @type {HayaSelectState} */
+  state = {
+    currentOptions: this.defaultCurrentOptions(),
+    selectContainerLayout: null,
+    endOfSelectLayout: null,
+    height: null,
+    loadedOptions: this.defaultLoadedOptions(),
+    loadOptionsAppliedRequestId: 0,
+    loadOptionsRequestId: 0,
+    page: 1,
+    pageInputFocused: false,
+    pageInputValue: "1",
+    pageSize: null,
+    opened: false,
+    optionsContainerLayout: null,
+    optionsPlacement: undefined,
+    optionsTop: undefined,
+    optionsVisibility: undefined,
+    optionsWidth: undefined,
+    scrollLeft: Platform.OS == "web" ? document.documentElement.scrollLeft : null,
+    scrollTop: Platform.OS == "web" ? document.documentElement.scrollTop : null,
+    totalCount: null,
+    toggled: this.defaultToggled()
+  }
 
   isDebugEnabled = () => Boolean(this.p.debug)
 
@@ -205,37 +259,6 @@ export default memo(shapeComponent(class HayaSelect extends ShapeComponent {
         }
       }
     }
-
-    this.setInstance({
-      endOfSelectRef: useRef(),
-      optionsContainerRef: useRef(),
-      pageInputRef: useRef(),
-      searchTextInputRef: useRef(),
-      selectContainerRef: useRef()
-    })
-    this.useStates({
-      currentOptions: () => this.defaultCurrentOptions(),
-      selectContainerLayout: null,
-      endOfSelectLayout: null,
-      height: null,
-      loadedOptions: () => this.defaultLoadedOptions(),
-      loadOptionsAppliedRequestId: 0,
-      loadOptionsRequestId: 0,
-      page: 1,
-      pageInputFocused: false,
-      pageInputValue: "1",
-      pageSize: null,
-      opened: false,
-      optionsContainerLayout: null,
-      optionsPlacement: undefined,
-      optionsTop: undefined,
-      optionsVisibility: undefined,
-      optionsWidth: undefined,
-      scrollLeft: Platform.OS == "web" ? document.documentElement.scrollLeft : null,
-      scrollTop: Platform.OS == "web" ? document.documentElement.scrollTop : null,
-      totalCount: null,
-      toggled: () => this.defaultToggled()
-    })
 
     const windowTarget = Platform.OS == "web" && typeof window != "undefined" ? window : null
 
@@ -345,7 +368,10 @@ export default memo(shapeComponent(class HayaSelect extends ShapeComponent {
     return Number.isFinite(this.s.pageSize) && this.s.pageSize > 0 ? this.s.pageSize : null
   }
 
-  defaultToggled = () => ("toggled" in this.props) ? this.p.toggled : this.props.defaultToggled || {}
+  defaultToggled() {
+    return ("toggled" in this.props) ? this.p.toggled : this.props.defaultToggled || {}
+  }
+
   getToggled = () => ("toggled" in this.props) ? this.p.toggled : this.s.toggled
   getValues = () => ("values" in this.props)
     ? (Array.isArray(this.p.values) ? this.p.values : [])
@@ -424,7 +450,7 @@ export default memo(shapeComponent(class HayaSelect extends ShapeComponent {
 
     if (Object.keys(newState).length > 0) {
       if (this.isDebugEnabled()) this.debugLog("componentDidUpdate", {syncingKeys: Object.keys(newState)})
-      this.setState(newState)
+      this.s.toggled = newState.toggled
     }
   }
 
@@ -644,14 +670,14 @@ export default memo(shapeComponent(class HayaSelect extends ShapeComponent {
     const {options} = this.parseOptionsResult(result)
     if (this.isDebugEnabled()) this.debugLog("loadDefaultValuesFromOptionsCallback.result", {loadedOptionsCount: options?.length || 0})
 
-    this.setState({currentOptions: this.state.currentOptions.concat(options)})
+    this.s.currentOptions = this.state.currentOptions.concat(options)
   }
 
   loadOptions = async ({page} = {}) => {
     const {options} = this.p
     const searchValue = this.getSearchText()
     const requestId = ++this.latestLoadOptionsRequestId
-    this.setState({loadOptionsRequestId: requestId})
+    this.s.loadOptionsRequestId = requestId
     if (this.isDebugEnabled()) this.debugLog("loadOptions", {
       page,
       requestId,
@@ -730,14 +756,12 @@ export default memo(shapeComponent(class HayaSelect extends ShapeComponent {
       loadedOptionsCount: loadedOptions.length
     })
 
-    this.setState({
-      loadedOptions,
-      loadOptionsAppliedRequestId: requestId,
-      page: 1,
-      pageInputValue: "1",
-      pageSize: null,
-      totalCount: null
-    })
+    this.s.loadedOptions = loadedOptions
+    this.s.loadOptionsAppliedRequestId = requestId
+    this.s.page = 1
+    this.s.pageInputValue = "1"
+    this.s.pageSize = null
+    this.s.totalCount = null
   }
 
   onDimensionsChange = ({window}) => {
@@ -745,7 +769,9 @@ export default memo(shapeComponent(class HayaSelect extends ShapeComponent {
     this.windowHeight = window.height
   }
 
-  onSelectContainerLayout = (e) => this.setState({selectContainerLayout: Object.assign({}, digg(e, "nativeEvent", "layout"))})
+  onSelectContainerLayout = (e) => {
+    this.s.selectContainerLayout = Object.assign({}, digg(e, "nativeEvent", "layout"))
+  }
   onEndOfSelectLayout = (e) => {
     const endOfSelectLayout = Object.assign({}, digg(e, "nativeEvent", "layout"))
     const newState = {endOfSelectLayout}
@@ -760,7 +786,9 @@ export default memo(shapeComponent(class HayaSelect extends ShapeComponent {
       }
     })
   }
-  onOptionsContainerLayout = (e) => this.setState({optionsContainerLayout: Object.assign({}, digg(e, "nativeEvent", "layout"))})
+  onOptionsContainerLayout = (e) => {
+    this.s.optionsContainerLayout = Object.assign({}, digg(e, "nativeEvent", "layout"))
+  }
 
   onSelectClicked = (e) => {
     e.preventDefault()
@@ -781,6 +809,7 @@ export default memo(shapeComponent(class HayaSelect extends ShapeComponent {
   closeOptions({options} = {}) {
     const closedOptions = options || this.getCurrentOptions()
     if (this.isDebugEnabled()) this.debugLog("closeOptions", {closedOptionsCount: closedOptions?.length || 0})
+    this.callOptionsPositionAboveIfOutsideScreen = false
 
     this.setState(
       {
@@ -880,13 +909,15 @@ export default memo(shapeComponent(class HayaSelect extends ShapeComponent {
   }
 
   setOptionsPositionAboveIfOutsideScreen() {
+    if (!this.s.opened) return
+
     const {windowHeight} = this.tt
     const {optionsContainerLayout} = this.s
     const endOfSelectLayout = this.s.endOfSelectLayout
 
     if (!endOfSelectLayout) {
       if (this.isDebugEnabled()) this.debugLog("setOptionsPositionAboveIfOutsideScreen", {placement: "below", reason: "missing-end-of-select-layout"})
-      this.setState({optionsVisibility: "visible"})
+      this.s.optionsVisibility = "visible"
       return
     }
 
@@ -899,11 +930,13 @@ export default memo(shapeComponent(class HayaSelect extends ShapeComponent {
       this.setOptionsPositionAbove()
     } else {
       if (this.isDebugEnabled()) this.debugLog("setOptionsPositionAboveIfOutsideScreen", {placement: "below"})
-      this.setState({optionsVisibility: "visible"})
+      this.s.optionsVisibility = "visible"
     }
   }
 
   setOptionsPositionAbove() {
+    if (!this.s.opened) return
+
     const {endOfSelectLayout} = this.s
     if (this.isDebugEnabled()) this.debugLog("setOptionsPositionAbove")
 
@@ -919,6 +952,8 @@ export default memo(shapeComponent(class HayaSelect extends ShapeComponent {
   }
 
   setOptionsPositionBelow() {
+    if (!this.s.opened) return
+
     if (this.isDebugEnabled()) this.debugLog("setOptionsPositionBelow")
     this.setState(
       {
@@ -943,10 +978,8 @@ export default memo(shapeComponent(class HayaSelect extends ShapeComponent {
   onAnythingScrolled = () => {
     if (this.isDebugEnabled()) this.debugLog("onAnythingScrolled", {opened: this.s.opened})
     if (this.s.opened) {
-      this.setState({
-        scrollLeft: Platform.OS == "web" ? document.documentElement.scrollLeft : null,
-        scrollTop: Platform.OS == "web" ? document.documentElement.scrollTop : null
-      })
+      this.s.scrollLeft = Platform.OS == "web" ? document.documentElement.scrollLeft : null
+      this.s.scrollTop = Platform.OS == "web" ? document.documentElement.scrollTop : null
       this.setOptionsPosition()
     }
   }
@@ -1051,7 +1084,7 @@ export default memo(shapeComponent(class HayaSelect extends ShapeComponent {
     const nextPage = Math.min(Math.max(Math.floor(page), 1), totalPages)
 
     if (nextPage == this.getActivePage()) {
-      this.setState({pageInputValue: String(this.getActivePage())})
+      this.s.pageInputValue = String(this.getActivePage())
       return
     }
 
@@ -1078,15 +1111,13 @@ export default memo(shapeComponent(class HayaSelect extends ShapeComponent {
   }
 
   onPaginationInputFocus = () => {
-    this.setState({
-      pageInputFocused: true,
-      pageInputValue: String(this.getActivePage())
-    })
+    this.s.pageInputFocused = true
+    this.s.pageInputValue = String(this.getActivePage())
   }
 
   /** @param {string} value */
   onPaginationInputChange = (value) => {
-    this.setState({pageInputValue: value})
+    this.s.pageInputValue = value
   }
 
   /** @param {import("react").SyntheticEvent} event */
@@ -1118,20 +1149,16 @@ export default memo(shapeComponent(class HayaSelect extends ShapeComponent {
     const totalPages = this.paginationTotalPages()
 
     if (!totalPages) {
-      this.setState({
-        pageInputFocused: false,
-        pageInputValue: String(this.getActivePage())
-      })
+      this.s.pageInputFocused = false
+      this.s.pageInputValue = String(this.getActivePage())
       return
     }
 
     const nextPage = Number(this.s.pageInputValue)
 
     if (!Number.isFinite(nextPage)) {
-      this.setState({
-        pageInputFocused: false,
-        pageInputValue: String(this.getActivePage())
-      })
+      this.s.pageInputFocused = false
+      this.s.pageInputValue = String(this.getActivePage())
       return
     }
 
@@ -1475,7 +1502,13 @@ export default memo(shapeComponent(class HayaSelect extends ShapeComponent {
       this.p.onChangeValue(optionValue)
     }
 
-    this.setState(newState)
+    if ("toggled" in newState) {
+      this.s.toggled = newState.toggled
+    }
+
+    if ("currentOptions" in newState) {
+      this.s.currentOptions = newState.currentOptions
+    }
   }
 
   stylingFor(stylingName, style = {}, caches = []) {
@@ -1598,7 +1631,7 @@ export default memo(shapeComponent(class HayaSelect extends ShapeComponent {
 
     if (Array.isArray(values) && values.length === 0) {
       if (this.s.currentOptions?.length) {
-        this.setState({currentOptions: []})
+        this.s.currentOptions = []
       }
 
       return
@@ -1610,7 +1643,11 @@ export default memo(shapeComponent(class HayaSelect extends ShapeComponent {
     const stateValues = this.s.currentOptions?.map((currentOption) => currentOption.value)
 
     if (anythingDifferent(currentValues, stateValues)) {
-      this.setState({currentOptions})
+      this.s.currentOptions = currentOptions
     }
   }
-}))
+}
+
+const HayaSelectShapeComponent = shapeComponent(HayaSelect)
+
+export default memo(HayaSelectShapeComponent)

--- a/src/select/index.jsx
+++ b/src/select/index.jsx
@@ -372,6 +372,10 @@ class HayaSelect extends ShapeComponent {
     return ("toggled" in this.props) ? this.p.toggled : this.props.defaultToggled || {}
   }
 
+  portalName() {
+    return nameForComponentWithMultiple(this) || `haya-select-${String(idForComponent(this))}`
+  }
+
   getToggled = () => ("toggled" in this.props) ? this.p.toggled : this.s.toggled
   getValues = () => ("values" in this.props)
     ? (Array.isArray(this.p.values) ? this.p.values : [])
@@ -619,7 +623,7 @@ class HayaSelect extends ShapeComponent {
           ref={endOfSelectRef}
         />
         {opened && this.p.optionsPortal &&
-          <Portal>
+          <Portal name={this.portalName()}>
             {this.optionsContainer()}
           </Portal>
         }

--- a/src/select/index.jsx
+++ b/src/select/index.jsx
@@ -111,7 +111,44 @@ const dataSets = {}
  * @property {Record<string|number, string>} toggled
  */
 
-/** @returns {string} */
+/**
+ * @typedef {object} HayaSelectLayout
+ * @property {number} [top]
+ * @property {number} [left]
+ * @property {number} [width]
+ * @property {number} [height]
+ */
+
+/**
+ * @typedef {object} HayaSelectOptionRenderContext
+ * @property {string|undefined} icon
+ * @property {"current"|"option"} mode
+ * @property {HayaSelectOption} option
+ * @property {boolean} selected
+ * @property {HayaSelectToggleOption|undefined} toggleOption
+ * @property {string|undefined} toggleValue
+ * @property {Record<string|number, string>} toggled
+ */
+
+/**
+ * @typedef {object} HayaSelectOnChangePayload
+ * @property {import("react").SyntheticEvent} event
+ * @property {Array<HayaSelectOption>} options
+ * @property {Record<string|number, string>} toggles
+ */
+
+/**
+ * @typedef {object} HayaSelectStylingContext
+ * @property {boolean} opened
+ * @property {"above"|"below"|undefined} optionsPlacement
+ * @property {HayaSelectState} state
+ * @property {Record<string, any>} style
+ */
+
+/**
+ * @param {ShapeComponent<HayaSelectProps, HayaSelectState>} component
+ * @returns {string}
+ */
 const nameForComponentWithMultiple = (component) => {
   let name = nameForComponent(component)
 
@@ -228,8 +265,14 @@ class HayaSelect extends ShapeComponent {
     toggled: this.defaultToggled()
   }
 
+  /** @returns {boolean} */
   isDebugEnabled = () => Boolean(this.p.debug)
 
+  /**
+   * @param {string} functionName
+   * @param {Record<string, any>} [details]
+   * @returns {void}
+   */
   debugLog = (functionName, details = undefined) => {
     if (!this.isDebugEnabled()) return
 
@@ -298,6 +341,7 @@ class HayaSelect extends ShapeComponent {
     }
   }
 
+  /** @returns {Array<HayaSelectOption>} */
   defaultCurrentOptions() {
     const {defaultValue, defaultValues, values} = this.props
     const {options} = this.p
@@ -312,6 +356,7 @@ class HayaSelect extends ShapeComponent {
     )
   }
 
+  /** @returns {Array<HayaSelectOption>|undefined} */
   defaultLoadedOptions() {
     const {options} = this.p
 
@@ -368,18 +413,25 @@ class HayaSelect extends ShapeComponent {
     return Number.isFinite(this.s.pageSize) && this.s.pageSize > 0 ? this.s.pageSize : null
   }
 
+  /** @returns {Record<string|number, string>} */
   defaultToggled() {
     return ("toggled" in this.props) ? this.p.toggled : this.props.defaultToggled || {}
   }
 
+  /** @returns {string} */
   portalName() {
     return nameForComponentWithMultiple(this) || `haya-select-${String(idForComponent(this))}`
   }
 
+  /** @returns {Record<string|number, string>} */
   getToggled = () => ("toggled" in this.props) ? this.p.toggled : this.s.toggled
+
+  /** @returns {Array<string|number>} */
   getValues = () => ("values" in this.props)
     ? (Array.isArray(this.p.values) ? this.p.values : [])
     : (Array.isArray(this.s.currentOptions) ? this.s.currentOptions : []).map((currentOption) => currentOption.value)
+
+  /** @returns {Array<HayaSelectOption|{value: string|number}|undefined>} */
   getCurrentOptions = () => {
     if ("values" in this.props && typeof this.props.values != "undefined") {
       if (Array.isArray(this.p.values) && this.p.values.length === 0) return []
@@ -413,6 +465,7 @@ class HayaSelect extends ShapeComponent {
     return this.s.currentOptions
   }
 
+  /** @returns {Array<string|number>} */
   getCurrentOptionValues() {
     if ("values" in this.props) {
       return Array.isArray(this.p.values) ? this.p.values : []
@@ -458,6 +511,7 @@ class HayaSelect extends ShapeComponent {
     }
   }
 
+  /** @returns {import("react").ReactNode} */
   render() {
     const {endOfSelectRef} = this.tt
     const {transparent} = this.p
@@ -636,6 +690,7 @@ class HayaSelect extends ShapeComponent {
     )
   }
 
+  /** @returns {Array<string|number>|string|number|undefined} */
   defaultValues () {
     const {attribute, defaultValue, defaultValues, defaultValuesFromOptions, model} = this.props
 
@@ -650,6 +705,7 @@ class HayaSelect extends ShapeComponent {
     }
   }
 
+  /** @returns {boolean} */
   isActive() {
     if (this.tt.endOfSelectRef.current) {
       return true
@@ -658,6 +714,7 @@ class HayaSelect extends ShapeComponent {
     return false
   }
 
+  /** @returns {Promise<void>} */
   async loadDefaultValuesFromOptionsCallback() {
     const defaultValues = this.defaultValues()
 
@@ -677,6 +734,10 @@ class HayaSelect extends ShapeComponent {
     this.s.currentOptions = this.state.currentOptions.concat(options)
   }
 
+  /**
+   * @param {{page?: number}} [params]
+   * @returns {Promise<void>}
+   */
   loadOptions = async ({page} = {}) => {
     const {options} = this.p
     const searchValue = this.getSearchText()
@@ -731,6 +792,10 @@ class HayaSelect extends ShapeComponent {
     })
   }
 
+  /**
+   * @param {{key: string, loadedOption: HayaSelectOption}}
+   * @returns {import("react").ReactNode}
+   */
   hayaSelectOption({key, loadedOption}) {
     if (loadedOption.type == "group") {
       return <OptionGroup key={key} option={loadedOption} />
@@ -750,6 +815,12 @@ class HayaSelect extends ShapeComponent {
     )
   }
 
+  /**
+   * @param {Array<HayaSelectOption>} options
+   * @param {string} [searchValue]
+   * @param {number} [requestId]
+   * @returns {void}
+   */
   loadOptionsFromArray(options, searchValue, requestId = this.latestLoadOptionsRequestId) {
     const lowerSearchValue = searchValue?.toLowerCase()
     const loadedOptions = options.filter(({text}) => !lowerSearchValue || text?.toLowerCase()?.includes(lowerSearchValue))
@@ -768,14 +839,27 @@ class HayaSelect extends ShapeComponent {
     this.s.totalCount = null
   }
 
+  /**
+   * @param {{window: {width: number, height: number}}} event
+   * @returns {void}
+   */
   onDimensionsChange = ({window}) => {
     this.windowWidth = window.width
     this.windowHeight = window.height
   }
 
+  /**
+   * @param {{nativeEvent?: {layout?: HayaSelectLayout}}} e
+   * @returns {void}
+   */
   onSelectContainerLayout = (e) => {
     this.s.selectContainerLayout = Object.assign({}, digg(e, "nativeEvent", "layout"))
   }
+
+  /**
+   * @param {{nativeEvent?: {layout?: HayaSelectLayout}}} e
+   * @returns {void}
+   */
   onEndOfSelectLayout = (e) => {
     const endOfSelectLayout = Object.assign({}, digg(e, "nativeEvent", "layout"))
     const newState = {endOfSelectLayout}
@@ -790,10 +874,19 @@ class HayaSelect extends ShapeComponent {
       }
     })
   }
+
+  /**
+   * @param {{nativeEvent?: {layout?: HayaSelectLayout}}} e
+   * @returns {void}
+   */
   onOptionsContainerLayout = (e) => {
     this.s.optionsContainerLayout = Object.assign({}, digg(e, "nativeEvent", "layout"))
   }
 
+  /**
+   * @param {import("react").SyntheticEvent} e
+   * @returns {void}
+   */
   onSelectClicked = (e) => {
     e.preventDefault()
     e.stopPropagation()
@@ -810,6 +903,10 @@ class HayaSelect extends ShapeComponent {
 
   onSearchTextInputChangedDebounced = debounce(this.tt.loadOptions, 200)
 
+  /**
+   * @param {{options?: Array<HayaSelectOption>}} [params]
+   * @returns {void}
+   */
   closeOptions({options} = {}) {
     const closedOptions = options || this.getCurrentOptions()
     if (this.isDebugEnabled()) this.debugLog("closeOptions", {closedOptionsCount: closedOptions?.length || 0})
@@ -840,8 +937,10 @@ class HayaSelect extends ShapeComponent {
     if (this.p.onBlur) this.p.onBlur()
   }
 
+  /** @returns {string} */
   getSearchText = () => this.searchTextValue || ""
 
+  /** @returns {void} */
   resetSearchTextInput = () => {
     this.searchTextValue = ""
     const input = this.tt.searchTextInputRef.current
@@ -859,6 +958,10 @@ class HayaSelect extends ShapeComponent {
     }
   }
 
+  /**
+   * @param {string} searchText
+   * @returns {void}
+   */
   onChangeSearchText = (searchText) => {
     if (this.isDebugEnabled()) this.debugLog("onChangeSearchText", {searchText, currentPage: this.s.page})
     this.searchTextValue = searchText
@@ -870,6 +973,7 @@ class HayaSelect extends ShapeComponent {
     }
   }
 
+  /** @returns {void} */
   openOptions() {
     if (this.isDebugEnabled()) this.debugLog("openOptions", {
       currentOptionsCount: this.getCurrentOptions()?.length || 0,
@@ -900,8 +1004,10 @@ class HayaSelect extends ShapeComponent {
     if (this.p.onFocus) this.p.onFocus()
   }
 
+  /** @returns {void} */
   focusTextInput = () => digg(this.tt.searchTextInputRef, "current")?.focus()
 
+  /** @returns {void} */
   setOptionsPosition() {
     if (!this.isActive()) {
       return // Debounce after un-mount handeling.
@@ -912,6 +1018,7 @@ class HayaSelect extends ShapeComponent {
     this.setOptionsPositionBelow()
   }
 
+  /** @returns {void} */
   setOptionsPositionAboveIfOutsideScreen() {
     if (!this.s.opened) return
 
@@ -938,6 +1045,7 @@ class HayaSelect extends ShapeComponent {
     }
   }
 
+  /** @returns {void} */
   setOptionsPositionAbove() {
     if (!this.s.opened) return
 
@@ -955,6 +1063,7 @@ class HayaSelect extends ShapeComponent {
     )
   }
 
+  /** @returns {void} */
   setOptionsPositionBelow() {
     if (!this.s.opened) return
 
@@ -970,6 +1079,7 @@ class HayaSelect extends ShapeComponent {
     )
   }
 
+  /** @returns {void} */
   onAnythingResized = () => {
     if (this.isDebugEnabled()) this.debugLog("onAnythingResized", {opened: this.s.opened})
     if (this.s.opened) {
@@ -979,6 +1089,7 @@ class HayaSelect extends ShapeComponent {
 
   onAnythingResizedDebounced = debounce(this.tt.onAnythingResized, 25)
 
+  /** @returns {void} */
   onAnythingScrolled = () => {
     if (this.isDebugEnabled()) this.debugLog("onAnythingScrolled", {opened: this.s.opened})
     if (this.s.opened) {
@@ -990,6 +1101,7 @@ class HayaSelect extends ShapeComponent {
 
   onAnythingScrolledDebounced = debounce(this.tt.onAnythingScrolled, 25)
 
+  /** @returns {void} */
   onPressOutsideOptions = () => {
     if (this.isDebugEnabled()) this.debugLog("onPressOutsideOptions", {opened: this.s.opened})
     // If options are open and a click is made outside of the options container
@@ -1061,6 +1173,10 @@ class HayaSelect extends ShapeComponent {
     return items
   }
 
+  /**
+   * @param {number} totalPages
+   * @returns {string}
+   */
   paginationDisplayValue(totalPages) {
     const activePage = this.getActivePage()
     const fallbackText = `Page ${activePage} of ${totalPages}`
@@ -1072,6 +1188,10 @@ class HayaSelect extends ShapeComponent {
     }) || fallbackText
   }
 
+  /**
+   * @param {number} totalPages
+   * @returns {string}
+   */
   paginationInputValue(totalPages) {
     if (this.s.pageInputFocused) return this.s.pageInputValue
 
@@ -1114,6 +1234,7 @@ class HayaSelect extends ShapeComponent {
     this.setPaginationPage(this.getActivePage() + 1)
   }
 
+  /** @returns {void} */
   onPaginationInputFocus = () => {
     this.s.pageInputFocused = true
     this.s.pageInputValue = String(this.getActivePage())
@@ -1322,6 +1443,7 @@ class HayaSelect extends ShapeComponent {
     )
   }
 
+  /** @returns {import("react").ReactNode|null} */
   optionsContainer() {
     const {selectContainerLayout, loadedOptions, endOfSelectLayout, optionsContainerLayout, optionsPlacement, optionsVisibility} = this.s
     let left, top
@@ -1407,6 +1529,11 @@ class HayaSelect extends ShapeComponent {
     )
   }
 
+  /**
+   * @param {import("react").SyntheticEvent} event
+   * @param {HayaSelectOption} loadedOption
+   * @returns {void}
+   */
   onOptionClicked = (event, loadedOption) => {
     event.preventDefault()
     event.stopPropagation()
@@ -1487,6 +1614,7 @@ class HayaSelect extends ShapeComponent {
     if (!multiple) this.closeOptions({options})
 
     if (onChange) {
+      /** @type {HayaSelectOnChangePayload} */
       onChange({
         event,
         options,
@@ -1515,10 +1643,17 @@ class HayaSelect extends ShapeComponent {
     }
   }
 
+  /**
+   * @param {string} stylingName
+   * @param {Record<string, any>} [style]
+   * @param {Array<any>} [caches]
+   * @returns {Record<string, any>}
+   */
   stylingFor(stylingName, style = {}, caches = []) {
     let customStyling = dig(this, "props", "styles", stylingName)
 
     if (typeof customStyling == "function") {
+      /** @type {HayaSelectStylingContext} */
       customStyling = customStyling({
         opened: this.s.opened,
         optionsPlacement: this.s.optionsPlacement,
@@ -1534,6 +1669,10 @@ class HayaSelect extends ShapeComponent {
     return this.cache(`stylingFor-${stylingName}`, style, caches)
   }
 
+  /**
+   * @param {HayaSelectOption} option
+   * @returns {string|undefined}
+   */
   iconForOption(option) {
     const {toggleOptions} = this.props || {}
     const toggled = this.getToggled()
@@ -1550,6 +1689,11 @@ class HayaSelect extends ShapeComponent {
     }
   }
 
+  /**
+   * @param {HayaSelectOption} option
+   * @param {"current"|"option"} mode
+   * @returns {import("react").ReactNode}
+   */
   presentOption = (option, mode) => {
     const {optionContent, toggleOptions} = this.props || {}
     const toggled = this.getToggled()
@@ -1593,6 +1737,7 @@ class HayaSelect extends ShapeComponent {
         }
         {(() => {
           if (optionContent) {
+            /** @type {HayaSelectOptionRenderContext} */
             contentNode = optionContent({icon, mode, option, selected, toggleOption, toggleValue, toggled})
           } else if (mode == "current" && option.currentContent) {
             contentNode = option.currentContent()
@@ -1630,6 +1775,7 @@ class HayaSelect extends ShapeComponent {
     )
   }
 
+  /** @returns {Promise<void>} */
   async setCurrentFromGivenValues() {
     const {options, values} = this.p
 

--- a/src/select/option.jsx
+++ b/src/select/option.jsx
@@ -1,9 +1,28 @@
+// @ts-check
+
 import PropTypes from "prop-types"
 import {Pressable} from "react-native"
 import React, {memo, useMemo} from "react"
 import {shapeComponent, ShapeComponent} from "set-state-compare/build/shape-component.js"
 
-export default memo(shapeComponent(class Option extends ShapeComponent {
+const PressableComponent = /** @type {any} */ (Pressable)
+
+/**
+ * @typedef {object} OptionProps
+ * @property {Array<string|number>} [currentOptionValues]
+ * @property {boolean} disabled
+ * @property {string} [icon]
+ * @property {(event: import("react").SyntheticEvent, option: Record<string, any>) => void} onOptionClicked
+ * @property {Record<string, any>} option
+ * @property {(option: Record<string, any>, mode: string) => import("react").ReactNode} presentOption
+ * @property {string} [selectedBackgroundColor]
+ * @property {string} [selectedHoverBackgroundColor]
+ */
+
+/** @typedef {{hover: boolean}} OptionState */
+
+/** @augments {ShapeComponent<OptionProps, OptionState>} */
+class Option extends ShapeComponent {
   static defaultProps = {
     disabled: false
   }
@@ -19,10 +38,9 @@ export default memo(shapeComponent(class Option extends ShapeComponent {
     selectedHoverBackgroundColor: PropTypes.string
   }
 
-  setup() {
-    this.useStates({
-      hover: false
-    })
+  /** @type {OptionState} */
+  state = {
+    hover: false
   }
 
   render() {
@@ -61,7 +79,7 @@ export default memo(shapeComponent(class Option extends ShapeComponent {
     }, [disabled, hover, selected, this.props.selectedBackgroundColor, this.props.selectedHoverBackgroundColor])
 
     return (
-      <Pressable
+      <PressableComponent
         dataSet={this.cache("pressableDataSet", {
           class: "select-option",
           disabled,
@@ -74,11 +92,21 @@ export default memo(shapeComponent(class Option extends ShapeComponent {
         style={style}
       >
         {this.p.presentOption(option, "option")}
-      </Pressable>
+      </PressableComponent>
     )
   }
 
-  onPointerOver = () => this.setState({hover: true})
-  onPointerOut = () => this.setState({hover: false})
+  onPointerOver = () => {
+    this.s.hover = true
+  }
+
+  onPointerOut = () => {
+    this.s.hover = false
+  }
+
   onPress = (e) => this.p.onOptionClicked(e, this.props.option)
-}))
+}
+
+const OptionShapeComponent = shapeComponent(Option)
+
+export default memo(OptionShapeComponent)

--- a/src/system-test-helpers.js
+++ b/src/system-test-helpers.js
@@ -23,6 +23,7 @@ export default class HayaSelectSystemTestHelper {
     this.testId = testId
     this.rootSelector = `[data-testid='${testId}']`
     this.componentSelector = `${this.rootSelector} [data-component='haya-select']`
+    this.chevronContainerSelector = `${this.rootSelector} [data-class='chevron-container']`
     this.selectContainerSelector = `${this.rootSelector} [data-class='select-container']`
     this.searchInputSelector = `${this.rootSelector} [data-class='search-text-input']`
     this.optionsContainerSelectorFallback = "[data-class='options-container']"
@@ -32,20 +33,31 @@ export default class HayaSelectSystemTestHelper {
   async open() {
     if (await this.isOpen()) return
 
-    const selectContainer = await this.systemTest.find(this.selectContainerSelector, {timeout: 5000})
-    const driver = this.systemTest.getDriver()
-    await driver.executeScript("arguments[0].scrollIntoView({block: 'center', inline: 'center'})", selectContainer)
-    await driver.executeScript("arguments[0].click()", selectContainer)
-    this._optionsContainerSelector = null
+    await waitFor({timeout: 5000}, async () => {
+      await this.systemTest.click(this.chevronContainerSelector)
+      this._optionsContainerSelector = null
+
+      const openedElements = await this.systemTest.all(`${this.componentSelector}[data-opened='true']`, {timeout: 0})
+
+      if (openedElements.length === 0) {
+        throw new Error(`Expected HayaSelect to open: ${this.testId}`)
+      }
+    })
   }
 
   /** @returns {Promise<void>} */
   async close() {
-    const selectContainer = await this.systemTest.find(this.selectContainerSelector, {timeout: 5000})
-    const driver = this.systemTest.getDriver()
-    await driver.executeScript("arguments[0].scrollIntoView({block: 'center', inline: 'center'})", selectContainer)
-    await driver.executeScript("arguments[0].click()", selectContainer)
-    await driver.executeScript("document.body && document.body.click()")
+    await waitFor({timeout: 5000}, async () => {
+      const openedElements = await this.systemTest.all(`${this.componentSelector}[data-opened='true']`, {timeout: 0})
+
+      if (openedElements.length > 0) {
+        await this.systemTest.click(this.chevronContainerSelector)
+      }
+
+      if ((await this.isOpen()) || openedElements.length > 0) {
+        throw new Error(`Expected HayaSelect to close: ${this.testId}`)
+      }
+    })
   }
 
   /** @returns {Promise<boolean>} */

--- a/src/system-test-helpers.js
+++ b/src/system-test-helpers.js
@@ -33,9 +33,16 @@ export default class HayaSelectSystemTestHelper {
   async open() {
     if (await this.isOpen()) return
 
+    let clickSent = false
+
     await waitFor({timeout: 5000}, async () => {
-      await this.systemTest.click(this.chevronContainerSelector)
-      this._optionsContainerSelector = null
+      if (await this.isOpen()) return
+
+      if (!clickSent) {
+        await this.systemTest.click(this.chevronContainerSelector)
+        this._optionsContainerSelector = null
+        clickSent = true
+      }
 
       const openedElements = await this.systemTest.all(`${this.componentSelector}[data-opened='true']`, {timeout: 0})
 
@@ -48,13 +55,11 @@ export default class HayaSelectSystemTestHelper {
   /** @returns {Promise<void>} */
   async close() {
     await waitFor({timeout: 5000}, async () => {
-      const openedElements = await this.systemTest.all(`${this.componentSelector}[data-opened='true']`, {timeout: 0})
-
-      if (openedElements.length > 0) {
+      if (await this.isOpen()) {
         await this.systemTest.click(this.chevronContainerSelector)
       }
 
-      if ((await this.isOpen()) || openedElements.length > 0) {
+      if (await this.isOpen()) {
         throw new Error(`Expected HayaSelect to close: ${this.testId}`)
       }
     })

--- a/src/system-test-helpers.js
+++ b/src/system-test-helpers.js
@@ -1,4 +1,5 @@
 import waitFor from "awaitery/build/wait-for.js"
+import {By} from "selenium-webdriver"
 
 /** @typedef {{systemTest: object, testId: string}} HayaSelectSystemTestHelperOptions */
 
@@ -31,20 +32,11 @@ export default class HayaSelectSystemTestHelper {
 
   /** @returns {Promise<void>} */
   async open() {
-    if (await this.isOpen()) return
-
-    let clickSent = false
+    await this.clickSelectContainer()
+    this._optionsContainerSelector = null
 
     await waitFor({timeout: 5000}, async () => {
-      if (await this.isOpen()) return
-
-      if (!clickSent) {
-        await this.systemTest.click(this.chevronContainerSelector)
-        this._optionsContainerSelector = null
-        clickSent = true
-      }
-
-      const openedElements = await this.systemTest.all(`${this.componentSelector}[data-opened='true']`, {timeout: 0})
+      const openedElements = await this.findElements(`${this.componentSelector}[data-opened='true']`)
 
       if (openedElements.length === 0) {
         throw new Error(`Expected HayaSelect to open: ${this.testId}`)
@@ -54,12 +46,12 @@ export default class HayaSelectSystemTestHelper {
 
   /** @returns {Promise<void>} */
   async close() {
-    await waitFor({timeout: 5000}, async () => {
-      if (await this.isOpen()) {
-        await this.systemTest.click(this.chevronContainerSelector)
-      }
+    await this.clickSelectContainer()
 
-      if (await this.isOpen()) {
+    await waitFor({timeout: 5000}, async () => {
+      const openedElements = await this.findElements(`${this.componentSelector}[data-opened='true']`)
+
+      if (openedElements.length > 0) {
         throw new Error(`Expected HayaSelect to close: ${this.testId}`)
       }
     })
@@ -67,26 +59,57 @@ export default class HayaSelectSystemTestHelper {
 
   /** @returns {Promise<boolean>} */
   async isOpen() {
-    const optionsContainerSelector = await this.optionsContainerSelector()
-    const options = await this.systemTest.all(optionsContainerSelector, {timeout: 0, useBaseSelector: false})
+    const openedElements = await this.findElements(`${this.componentSelector}[data-opened='true']`)
 
-    if (options.length > 0) return true
+    if (openedElements.length > 0) return true
 
-    const searchInputs = await this.systemTest.all(this.searchInputSelector, {timeout: 0, visible: true})
+    const searchInputs = await this.findVisibleElements(this.searchInputSelector)
 
     return searchInputs.length > 0
+  }
+
+  /** @returns {Promise<void>} */
+  async clickSelectContainer() {
+    const selectContainer = await this.systemTest.find(this.selectContainerSelector, {timeout: 5000})
+
+    await selectContainer.click()
+  }
+
+  /**
+   * @param {string} selector
+   * @returns {Promise<Array<import("selenium-webdriver").WebElement>>}
+   */
+  async findElements(selector) {
+    return await this.systemTest.getDriver().findElements(By.css(selector))
+  }
+
+  /**
+   * @param {string} selector
+   * @returns {Promise<Array<import("selenium-webdriver").WebElement>>}
+   */
+  async findVisibleElements(selector) {
+    const elements = await this.findElements(selector)
+    const visibleElements = []
+
+    for (const element of elements) {
+      if (await element.isDisplayed()) {
+        visibleElements.push(element)
+      }
+    }
+
+    return visibleElements
   }
 
   /** @returns {Promise<string>} */
   async optionsContainerSelector() {
     if (this._optionsContainerSelector) return this._optionsContainerSelector
 
-    const rootElements = await this.systemTest.all(this.rootSelector, {timeout: 0})
+    const rootElements = await this.findElements(this.rootSelector)
     const rootId = rootElements.length > 0 ? await rootElements[0].getAttribute("data-id") : null
     let elements = rootElements
 
     if (!rootId) {
-      elements = await this.systemTest.all(this.componentSelector, {timeout: 0})
+      elements = await this.findElements(this.componentSelector)
     }
 
     const id = rootId || (elements.length > 0 ? await elements[0].getAttribute("data-id") : null)
@@ -99,7 +122,7 @@ export default class HayaSelectSystemTestHelper {
   /** @returns {Promise<string[]>} */
   async optionTexts() {
     const optionsContainerSelector = await this.optionsContainerSelector()
-    const options = await this.systemTest.all(`${optionsContainerSelector} [data-class='select-option']`, {useBaseSelector: false, timeout: 0})
+    const options = await this.findElements(`${optionsContainerSelector} [data-class='select-option']`)
 
     return await Promise.all(options.map(async (option) => (await option.getText()).trim()))
   }
@@ -122,14 +145,14 @@ export default class HayaSelectSystemTestHelper {
     if (typeof value != "undefined") {
       await waitFor({timeout: 5000}, async () => {
         const optionsContainerSelector = await this.optionsContainerSelector()
-        const options = await this.systemTest.all(`${optionsContainerSelector} [data-class='select-option'][data-value='${value}']`, {useBaseSelector: false, timeout: 0})
+        const options = await this.findElements(`${optionsContainerSelector} [data-class='select-option'][data-value='${value}']`)
         const option = options[0]
 
         if (!option) {
           throw new Error(`No option for value: ${value}`)
         }
-        const driver = this.systemTest.getDriver()
-        await driver.executeScript("arguments[0].dispatchEvent(new MouseEvent('click', {bubbles: true, cancelable: true}))", option)
+
+        await option.click()
       })
       return
     }
@@ -137,13 +160,12 @@ export default class HayaSelectSystemTestHelper {
     if (typeof index == "number") {
       await waitFor({timeout: 5000}, async () => {
         const optionsContainerSelector = await this.optionsContainerSelector()
-        const options = await this.systemTest.all(`${optionsContainerSelector} [data-class='select-option']`, {useBaseSelector: false, timeout: 0})
+        const options = await this.findElements(`${optionsContainerSelector} [data-class='select-option']`)
         const option = options[index]
 
         if (!option) throw new Error(`No option at index: ${index}`)
 
-        const driver = this.systemTest.getDriver()
-        await driver.executeScript("arguments[0].dispatchEvent(new MouseEvent('click', {bubbles: true, cancelable: true}))", option)
+        await option.click()
       })
       return
     }
@@ -151,13 +173,13 @@ export default class HayaSelectSystemTestHelper {
     if (text) {
       await waitFor({timeout: 5000}, async () => {
         const optionsContainerSelector = await this.optionsContainerSelector()
-        const options = await this.systemTest.all(`${optionsContainerSelector} [data-class='select-option']`, {useBaseSelector: false})
+        const options = await this.findElements(`${optionsContainerSelector} [data-class='select-option']`)
 
         for (const option of options) {
           const optionText = (await option.getText()).trim()
 
           if (optionText === text) {
-            await this.systemTest.click(option)
+            await option.click()
             return
           }
         }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,9 @@
     "inlineSourceMap": true,
     "inlineSources": true,
     "jsx": "react",
+    "moduleResolution": "node",
     "outDir": "./build",
+    "rootDir": "./src",
     "sourceMap": false
   },
   "include": ["./src"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,8 @@
     "inlineSourceMap": true,
     "inlineSources": true,
     "jsx": "react",
-    "moduleResolution": "node",
+    "module": "esnext",
+    "moduleResolution": "bundler",
     "outDir": "./build",
     "rootDir": "./src",
     "sourceMap": false


### PR DESCRIPTION
## Summary
- move `HayaSelect` and `Option` state definitions into class-body `state = ...` declarations for better ShapeComponent typing
- replace callback-free `this.setState({...})` calls with direct `this.s.*` assignments where that is safe, and move refs to class-body `createRef()` fields
- switch ShapeComponent JSDoc generics to `@augments`, split `shapeComponent(...)` from `memo(...)`, and bump `set-state-compare` to `1.0.83`

## Validation
- `npm run lint`
- `npm run typecheck`

## Known issue
- `npm run test:dist` still fails in the placement flow
- focused reproduction: `SYSTEM_TEST_HOST=dist npx velocious test spec/system/haya-select-render-spec.js:407`
- current failure: `above wasn't expected be below`
