### PR TITLE
Disable watch mode in release builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "scripts": {
-    "build": "expo-module build",
+    "build": "EXPO_NONINTERACTIVE=1 expo-module build",
     "build:example:dist": "npm run build && EXPO_NONINTERACTIVE=1 cd example && npx expo export --platform web --output-dir ../dist",
     "clean": "expo-module clean",
     "lint": "expo-module lint",


### PR DESCRIPTION
## Summary
Make the package build script non-interactive so `npm publish` and `release:patch` do not enter TypeScript watch mode during the publish lifecycle.

## Validation
- `npm run build`
- `npm run lint`
- `npm run typecheck`
- `npm publish --dry-run`