### PR TITLE
Bump set-state-compare to 1.0.84

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -25,7 +25,7 @@
         "react-native-render-html": "^6.3.4",
         "react-native-vector-icons": "^10.2.0",
         "react-native-web": "~0.19.13",
-        "set-state-compare": "^1.0.83",
+        "set-state-compare": "^1.0.84",
         "ya-use-event-listener": "^0.1.1"
       },
       "devDependencies": {
@@ -35,7 +35,7 @@
       }
     },
     "..": {
-      "version": "1.0.102",
+      "version": "1.0.104",
       "license": "MIT",
       "dependencies": {
         "awaitery": "^1.0.13",
@@ -67,7 +67,7 @@
         "prop-types": "*",
         "react": "*",
         "react-native": "*",
-        "set-state-compare": ">= 1.0.83"
+        "set-state-compare": ">= 1.0.84"
       }
     },
     "node_modules/@0no-co/graphql.web": {
@@ -10502,9 +10502,9 @@
       }
     },
     "node_modules/set-state-compare": {
-      "version": "1.0.83",
-      "resolved": "https://registry.npmjs.org/set-state-compare/-/set-state-compare-1.0.83.tgz",
-      "integrity": "sha512-oAIaYX6zcWloYcoXSx8wAGRj0qj3MGoYcmwj4oIKQq4/TgVAO9gWqjFCXI2BXJvBP7/qzLV6J6ZFVfQPOwbokw==",
+      "version": "1.0.84",
+      "resolved": "https://registry.npmjs.org/set-state-compare/-/set-state-compare-1.0.84.tgz",
+      "integrity": "sha512-9n3zn0gbMaq+NJpAgc54zQXRQ8lV7b8TmDWJUIns9QS9MSij/mtaGAr5rCbLB+W1+tQ60KvDbgZyrWtDtXoDHg==",
       "license": "ISC",
       "dependencies": {
         "diggerize": "^1.0.5",

--- a/example/package.json
+++ b/example/package.json
@@ -26,7 +26,7 @@
     "react-native-render-html": "^6.3.4",
     "react-native-vector-icons": "^10.2.0",
     "react-native-web": "~0.19.13",
-    "set-state-compare": "^1.0.83",
+    "set-state-compare": "^1.0.84",
     "ya-use-event-listener": "^0.1.1"
   },
   "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "prop-types": "*",
         "react": "*",
         "react-native": "*",
-        "set-state-compare": ">= 1.0.83"
+        "set-state-compare": ">= 1.0.84"
       }
     },
     "node_modules/@0no-co/graphql.web": {
@@ -19604,9 +19604,9 @@
       }
     },
     "node_modules/set-state-compare": {
-      "version": "1.0.83",
-      "resolved": "https://registry.npmjs.org/set-state-compare/-/set-state-compare-1.0.83.tgz",
-      "integrity": "sha512-oAIaYX6zcWloYcoXSx8wAGRj0qj3MGoYcmwj4oIKQq4/TgVAO9gWqjFCXI2BXJvBP7/qzLV6J6ZFVfQPOwbokw==",
+      "version": "1.0.84",
+      "resolved": "https://registry.npmjs.org/set-state-compare/-/set-state-compare-1.0.84.tgz",
+      "integrity": "sha512-9n3zn0gbMaq+NJpAgc54zQXRQ8lV7b8TmDWJUIns9QS9MSij/mtaGAr5rCbLB+W1+tQ60KvDbgZyrWtDtXoDHg==",
       "license": "ISC",
       "dependencies": {
         "diggerize": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "prop-types": "*",
     "react": "*",
     "react-native": "*",
-    "set-state-compare": ">= 1.0.83"
+    "set-state-compare": ">= 1.0.84"
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }


### PR DESCRIPTION
## Summary
Bump `set-state-compare` to the latest published version in both the library peer dependency range and the example app dependency, and refresh the lockfiles.

## Validation
- `npm install`
- `(cd example && npm install)`
- `npm run lint`
- `npm run typecheck`