### PR TITLE
Make defaulted select props optional

### DIFF
--- a/src/select/index.jsx
+++ b/src/select/index.jsx
@@ -61,7 +61,7 @@ const dataSets = {}
  * @property {boolean} [debug]
  * @property {import("react").ReactNode} [id]
  * @property {object} [model]
- * @property {boolean} multiple
+ * @property {boolean} [multiple]
  * @property {string} [name]
  * @property {function(): import("react").ReactNode} [noOptionsText]
  * @property {function(import("react").SyntheticEvent=): void} [onBlur]
@@ -72,17 +72,17 @@ const dataSets = {}
  * @property {function({options: Array}): void} [onOptionsLoaded]
  * @property {function(object): import("react").ReactNode} [optionContent]
  * @property {Array<HayaSelectOption>|function(): (Array<HayaSelectOption>|HayaSelectOptionsResult)} options
- * @property {boolean} optionsAbsolute
- * @property {boolean} optionsPortal
+ * @property {boolean} [optionsAbsolute]
+ * @property {boolean} [optionsPortal]
  * @property {number} [optionsWidth]
  * @property {import("react").ReactNode} [placeholder]
  * @property {string} [selectedBackgroundColor]
  * @property {string} [selectedHoverBackgroundColor]
- * @property {boolean} search
+ * @property {boolean} [search]
  * @property {object} [styles]
  * @property {object} [toggled]
  * @property {Array<HayaSelectToggleOption>} [toggleOptions]
- * @property {boolean} transparent
+ * @property {boolean} [transparent]
  * @property {Array<string|number>} [values]
  */
 
@@ -186,10 +186,10 @@ class HayaSelect extends ShapeComponent {
     defaultValue: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     defaultValues: PropTypes.array,
     defaultValuesFromOptions: PropTypes.array,
-    debug: PropTypes.bool.isRequired,
+    debug: PropTypes.bool,
     id: PropTypes.node,
     model: PropTypes.object,
-    multiple: PropTypes.bool.isRequired,
+    multiple: PropTypes.bool,
     name: PropTypes.string,
     noOptionsText: PropTypes.func,
     onBlur: PropTypes.func,
@@ -211,13 +211,13 @@ class HayaSelect extends ShapeComponent {
       })),
       PropTypes.func
     ]).isRequired,
-    optionsAbsolute: PropTypes.bool.isRequired,
-    optionsPortal: PropTypes.bool.isRequired,
+    optionsAbsolute: PropTypes.bool,
+    optionsPortal: PropTypes.bool,
     optionsWidth: PropTypes.number,
     placeholder: PropTypes.node,
     selectedBackgroundColor: PropTypes.string,
     selectedHoverBackgroundColor: PropTypes.string,
-    search: PropTypes.bool.isRequired,
+    search: PropTypes.bool,
     styles: PropTypes.object,
     toggled: PropTypes.object,
     toggleOptions: PropTypes.arrayOf(PropTypes.shape({
@@ -225,7 +225,7 @@ class HayaSelect extends ShapeComponent {
       label: PropTypes.string.isRequired,
       value: PropTypes.string.isRequired
     })),
-    transparent: PropTypes.bool.isRequired,
+    transparent: PropTypes.bool,
     values: PropTypes.array
   })
 

--- a/src/select/index.jsx
+++ b/src/select/index.jsx
@@ -186,10 +186,10 @@ class HayaSelect extends ShapeComponent {
     defaultValue: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     defaultValues: PropTypes.array,
     defaultValuesFromOptions: PropTypes.array,
-    debug: PropTypes.bool,
+    debug: PropTypes.bool.isRequired,
     id: PropTypes.node,
     model: PropTypes.object,
-    multiple: PropTypes.bool,
+    multiple: PropTypes.bool.isRequired,
     name: PropTypes.string,
     noOptionsText: PropTypes.func,
     onBlur: PropTypes.func,
@@ -211,13 +211,13 @@ class HayaSelect extends ShapeComponent {
       })),
       PropTypes.func
     ]).isRequired,
-    optionsAbsolute: PropTypes.bool,
-    optionsPortal: PropTypes.bool,
+    optionsAbsolute: PropTypes.bool.isRequired,
+    optionsPortal: PropTypes.bool.isRequired,
     optionsWidth: PropTypes.number,
     placeholder: PropTypes.node,
     selectedBackgroundColor: PropTypes.string,
     selectedHoverBackgroundColor: PropTypes.string,
-    search: PropTypes.bool,
+    search: PropTypes.bool.isRequired,
     styles: PropTypes.object,
     toggled: PropTypes.object,
     toggleOptions: PropTypes.arrayOf(PropTypes.shape({
@@ -225,7 +225,7 @@ class HayaSelect extends ShapeComponent {
       label: PropTypes.string.isRequired,
       value: PropTypes.string.isRequired
     })),
-    transparent: PropTypes.bool,
+    transparent: PropTypes.bool.isRequired,
     values: PropTypes.array
   })
 


### PR DESCRIPTION
## Summary
- mark `multiple`, `optionsAbsolute`, `optionsPortal`, `search`, and `transparent` optional in `HayaSelectProps`
- align the runtime propTypes with the existing default props
- keep downstream callers from having to pass explicit `false` values just to satisfy typing

## Validation
- `npm run build`
- `npm run lint`
- `npm run typecheck`