### PR TITLE
Fix native select styles

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -36,7 +36,9 @@ export default function App() {
   const paginationPageSize = 5
   const paginationTotalCount = 24
   const placementStyleCallback = {
-    optionsContainer: ({optionsPlacement}: {optionsPlacement?: "above" | "below"}) => {
+    optionsContainer: ({optionsPlacement, style}: {optionsPlacement?: "above" | "below"; style: Record<string, unknown>}) => {
+      Object.freeze(style)
+
       if (optionsPlacement === "above") {
         return {
           borderBottomLeftRadius: 0,

--- a/src/select/index.jsx
+++ b/src/select/index.jsx
@@ -534,14 +534,11 @@ class HayaSelect extends ShapeComponent {
       borderRadius: transparent ? undefined : 4,
       borderWidth: transparent ? undefined : 1,
       color: "#000",
+      cursor: Platform.OS == "web" ? "pointer" : undefined,
       paddingTop: 5,
       paddingBottom: 5,
       paddingLeft: 5
     }, [transparent])}
-
-    if (Platform.OS == "web") {
-      selectContainerStyleActual.cursor = "pointer"
-    }
 
     if (opened) {
       // Prevent select from changing size once the content is replaced with search text once opened

--- a/src/select/index.jsx
+++ b/src/select/index.jsx
@@ -530,14 +530,18 @@ class HayaSelect extends ShapeComponent {
       flexDirection: "row",
       alignItems: "center",
       backgroundColor: transparent ? undefined : "#fff",
-      border: transparent ? undefined : "1px solid #999",
+      borderColor: transparent ? undefined : "#999",
       borderRadius: transparent ? undefined : 4,
+      borderWidth: transparent ? undefined : 1,
       color: "#000",
-      cursor: "pointer",
       paddingTop: 5,
       paddingBottom: 5,
       paddingLeft: 5
     }, [transparent])}
+
+    if (Platform.OS == "web") {
+      selectContainerStyleActual.cursor = "pointer"
+    }
 
     if (opened) {
       // Prevent select from changing size once the content is replaced with search text once opened
@@ -585,7 +589,7 @@ class HayaSelect extends ShapeComponent {
         >
           <View
             dataSet={this.currentSelectedDataSet ||= {class: "current-selected"}}
-            style={this.stylingFor("currentSelected", this.currentSelectedStyle ||= {width: "calc(100% - 25px)", flexWrap: "wrap", overflow: "hidden"})}
+            style={this.stylingFor("currentSelected", this.currentSelectedStyle ||= {flex: 1, flexWrap: "wrap", overflow: "hidden"})}
           >
             {opened &&
               <TextInput
@@ -595,8 +599,8 @@ class HayaSelect extends ShapeComponent {
                 ref={this.tt.searchTextInputRef}
                 style={this.stylingFor("searchTextInput", this.searchTextInputStyle ||= {
                   width: "100%",
-                  border: 0,
-                  outline: "none",
+                  borderWidth: 0,
+                  outline: Platform.OS == "web" ? "none" : undefined,
                   padding: 0
                 })}
                 defaultValue={this.searchTextValue}
@@ -1316,7 +1320,8 @@ class HayaSelect extends ShapeComponent {
       <View
         dataSet={dataSets.paginationContainer ||= {class: "options-pagination"}}
         style={styles.paginationContainer ||= {
-          borderTop: "1px solid #e2e8f0",
+          borderTopColor: "#e2e8f0",
+          borderTopWidth: 1,
           padding: 8
         }}
       >
@@ -1331,8 +1336,9 @@ class HayaSelect extends ShapeComponent {
             style={styles[`paginationNavButton-${prevDisabled}`] ||= {
               alignItems: "center",
               backgroundColor: "#f8fafc",
-              border: "1px solid #cbd5e1",
+              borderColor: "#cbd5e1",
               borderRadius: 8,
+              borderWidth: 1,
               height: 30,
               justifyContent: "center",
               opacity: prevDisabled ? 0.4 : 1,
@@ -1352,8 +1358,9 @@ class HayaSelect extends ShapeComponent {
             style={styles.paginationLabelButton ||= {
               alignItems: "center",
               backgroundColor: "#f1f5f9",
-              border: "1px solid #cbd5e1",
+              borderColor: "#cbd5e1",
               borderRadius: 14,
+              borderWidth: 1,
               justifyContent: "center",
               minWidth: 140,
               paddingHorizontal: 10,
@@ -1372,10 +1379,10 @@ class HayaSelect extends ShapeComponent {
               ref={this.tt.pageInputRef}
               selectTextOnFocus
               style={styles.paginationInputStyle ||= {
-                border: 0,
+                borderWidth: 0,
                 color: "#0f172a",
                 fontSize: 12,
-                outline: "none",
+                outline: Platform.OS == "web" ? "none" : undefined,
                 padding: 0,
                 textAlign: "center",
                 width: 120
@@ -1390,8 +1397,9 @@ class HayaSelect extends ShapeComponent {
             style={styles[`paginationNavButton-${nextDisabled}`] ||= {
               alignItems: "center",
               backgroundColor: "#f8fafc",
-              border: "1px solid #cbd5e1",
+              borderColor: "#cbd5e1",
               borderRadius: 8,
+              borderWidth: 1,
               height: 30,
               justifyContent: "center",
               opacity: nextDisabled ? 0.4 : 1,
@@ -1460,9 +1468,10 @@ class HayaSelect extends ShapeComponent {
       visibility: optionsVisibility,
       width: this.p.optionsWidth || this.s.optionsWidth,
       backgroundColor: "#fff",
-      border: "1px solid #999",
+      borderColor: "#999",
+      borderWidth: 1,
       maxHeight: 300,
-      overflowY: "auto"
+      overflowY: Platform.OS == "web" ? "auto" : undefined
     }
 
     if (!this.p.optionsPortal) {
@@ -1656,6 +1665,7 @@ class HayaSelect extends ShapeComponent {
    */
   stylingFor(stylingName, style = {}, caches = []) {
     let customStyling = dig(this, "props", "styles", stylingName)
+    const baseStyle = {...style}
 
     if (typeof customStyling == "function") {
       /** @type {HayaSelectStylingContext} */
@@ -1663,12 +1673,12 @@ class HayaSelect extends ShapeComponent {
         opened: this.s.opened,
         optionsPlacement: this.s.optionsPlacement,
         state: this.state,
-        style
+        style: baseStyle
       })
     }
 
     if (customStyling) {
-      return Object.assign(style, customStyling)
+      return Object.assign({}, baseStyle, customStyling)
     }
 
     return this.cache(`stylingFor-${stylingName}`, style, caches)


### PR DESCRIPTION
## Summary
- replace web-only select border/calc defaults with React Native-compatible style fields
- keep web cursor/overflow behavior guarded to web
- merge custom style overrides into a fresh object so frozen rendered style objects are not mutated
- freeze the example style callback input to cover the immutable merge path in system tests

## Checks
- npm run lint
- npm run typecheck
- npm run test:dist