### PR TITLE
Support HayaSelect search input props

### DIFF
--- a/spec/system/haya-select-render-spec.js
+++ b/spec/system/haya-select-render-spec.js
@@ -167,6 +167,47 @@ describe("HayaSelect", () => {
     })
   })
 
+  it("keeps no-options content readable after filtering", async () => {
+    await timeout({errorMessage: "render test timed out: keeps no-options content readable after filtering", timeout: 30000}, async () => {
+      await runSystemTest(async (systemTest) => {
+        const helper = new HayaSelectSystemTestHelper({systemTest, testId: "hayaSelectRoot"})
+
+        await systemTest.findByTestID("hayaSelectRoot", {timeout: 5000})
+        await helper.open()
+
+        await systemTest.find(
+          "[data-testid='hayaSelectRoot'] [data-component='haya-select'][data-applied-request-id='1']",
+          {timeout: 5000}
+        )
+
+        await systemTest.interact(
+          {selector: helper.searchInputSelector},
+          "sendKeys",
+          Key.chord(Key.CONTROL, "a"),
+          Key.BACK_SPACE,
+          "not-a-real-option"
+        )
+
+        const optionsContainerSelector = await helper.optionsContainerSelector()
+
+        await waitFor({timeout: 5000}, async () => {
+          const noOptionsContainer = await systemTest.find(
+            `${optionsContainerSelector} [data-class='no-options-container']`,
+            {timeout: 0, useBaseSelector: false}
+          )
+          const paddingBottom = parseFloat(await noOptionsContainer.getCssValue("padding-bottom"))
+          const paddingTop = parseFloat(await noOptionsContainer.getCssValue("padding-top"))
+
+          if (paddingBottom < 10 || paddingTop < 10) {
+            throw new Error(`Expected no-options container vertical padding, got: top=${paddingTop}, bottom=${paddingBottom}`)
+          }
+        })
+
+        await helper.close()
+      })
+    })
+  })
+
   it("highlights selected options in multiple select", async () => {
     await timeout({errorMessage: "render test timed out: highlights selected options in multiple select", timeout: 30000}, async () => {
       await runSystemTest(async (systemTest) => {

--- a/src/select/index.jsx
+++ b/src/select/index.jsx
@@ -1557,8 +1557,18 @@ class HayaSelect extends ShapeComponent {
           })
         )}
         {loadedOptions?.length === 0 &&
-          <View dataSet={this.noOptionsContainerDataSet ||= {class: "no-options-container"}}>
-            <Text>{this.p.noOptionsText ? this.p.noOptionsText() : this.translate(".no_options_found")}</Text>
+          <View
+            dataSet={this.noOptionsContainerDataSet ||= {class: "no-options-container"}}
+            style={this.stylingFor("noOptionsContainer", this.noOptionsContainerStyle ||= {
+              paddingBottom: 10,
+              paddingLeft: 8,
+              paddingRight: 8,
+              paddingTop: 10
+            })}
+          >
+            <Text>
+              {this.p.noOptionsText ? this.p.noOptionsText() : this.translate(".no_options_found")}
+            </Text>
           </View>
         }
         {this.paginationControls()}

--- a/src/select/index.jsx
+++ b/src/select/index.jsx
@@ -79,6 +79,7 @@ const dataSets = {}
  * @property {string} [selectedBackgroundColor]
  * @property {string} [selectedHoverBackgroundColor]
  * @property {boolean} [search]
+ * @property {string} [searchPlaceholderTextColor]
  * @property {object} [styles]
  * @property {object} [toggled]
  * @property {Array<HayaSelectToggleOption>} [toggleOptions]
@@ -206,6 +207,7 @@ class HayaSelect extends ShapeComponent {
     optionsPortal: true,
     optionsWidth: null,
     search: false,
+    searchPlaceholderTextColor: undefined,
     transparent: false
   }
 
@@ -248,6 +250,7 @@ class HayaSelect extends ShapeComponent {
     selectedBackgroundColor: PropTypes.string,
     selectedHoverBackgroundColor: PropTypes.string,
     search: PropTypes.bool.isRequired,
+    searchPlaceholderTextColor: PropTypes.string,
     styles: PropTypes.object,
     toggled: PropTypes.object,
     toggleOptions: PropTypes.arrayOf(PropTypes.shape({
@@ -623,6 +626,7 @@ class HayaSelect extends ShapeComponent {
                 dataSet={this.searchTextInputDataSet ||= {class: "search-text-input"}}
                 onChangeText={this.tt.onChangeSearchText}
                 placeholder={this.translate(".search_dot_dot_dot")}
+                placeholderTextColor={this.p.searchPlaceholderTextColor}
                 ref={this.tt.searchTextInputRef}
                 style={this.stylingFor("searchTextInput", this.searchTextInputStyle ||= {
                   width: "100%",

--- a/src/select/index.jsx
+++ b/src/select/index.jsx
@@ -623,7 +623,6 @@ class HayaSelect extends ShapeComponent {
           >
             {opened &&
               <TextInput
-                {...this.p.searchTextInputProps}
                 dataSet={this.searchTextInputDataSet ||= {class: "search-text-input"}}
                 onChangeText={this.tt.onChangeSearchText}
                 placeholder={this.translate(".search_dot_dot_dot")}
@@ -635,6 +634,7 @@ class HayaSelect extends ShapeComponent {
                   padding: 0
                 })}
                 defaultValue={this.searchTextValue}
+                {...this.p.searchTextInputProps}
               />
             }
             {!opened &&

--- a/src/select/index.jsx
+++ b/src/select/index.jsx
@@ -79,7 +79,7 @@ const dataSets = {}
  * @property {string} [selectedBackgroundColor]
  * @property {string} [selectedHoverBackgroundColor]
  * @property {boolean} [search]
- * @property {string} [searchPlaceholderTextColor]
+ * @property {import("react-native").TextInputProps} [searchTextInputProps]
  * @property {object} [styles]
  * @property {object} [toggled]
  * @property {Array<HayaSelectToggleOption>} [toggleOptions]
@@ -207,7 +207,7 @@ class HayaSelect extends ShapeComponent {
     optionsPortal: true,
     optionsWidth: null,
     search: false,
-    searchPlaceholderTextColor: undefined,
+    searchTextInputProps: undefined,
     transparent: false
   }
 
@@ -250,7 +250,7 @@ class HayaSelect extends ShapeComponent {
     selectedBackgroundColor: PropTypes.string,
     selectedHoverBackgroundColor: PropTypes.string,
     search: PropTypes.bool.isRequired,
-    searchPlaceholderTextColor: PropTypes.string,
+    searchTextInputProps: PropTypes.object,
     styles: PropTypes.object,
     toggled: PropTypes.object,
     toggleOptions: PropTypes.arrayOf(PropTypes.shape({
@@ -623,10 +623,10 @@ class HayaSelect extends ShapeComponent {
           >
             {opened &&
               <TextInput
+                {...this.p.searchTextInputProps}
                 dataSet={this.searchTextInputDataSet ||= {class: "search-text-input"}}
                 onChangeText={this.tt.onChangeSearchText}
                 placeholder={this.translate(".search_dot_dot_dot")}
-                placeholderTextColor={this.p.searchPlaceholderTextColor}
                 ref={this.tt.searchTextInputRef}
                 style={this.stylingFor("searchTextInput", this.searchTextInputStyle ||= {
                   width: "100%",


### PR DESCRIPTION
Adds a searchTextInputProps prop and forwards it to the internal search TextInput before HayaSelect's required search props. This lets consumers set native TextInput options such as placeholderTextColor, cursorColor, selectionColor, keyboardAppearance, and auto-correction while HayaSelect keeps ownership of search behavior.

Also adds default padding to noOptionsContainer so empty filtered results stay readable.

Validation:
- npm run lint
- npm run typecheck
- npm run test:dist