### PR TITLE
Fix pagination ellipsis text rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Render pagination ellipses without literal text nodes to avoid React Native Web `View` text-child warnings.
 - Fix crash rendering chips when `values` include ids that have no matching entry in `options` (e.g. URL deep-link with options still loading).
 - Fix crash when opening the select before layout measurements are available.
 - Update options width when layout data arrives after opening.

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -34,7 +34,7 @@ export default function App() {
   ]
   const staleValues = ["one", "missing"]
   const paginationPageSize = 5
-  const paginationTotalCount = 24
+  const paginationTotalCount = 54
   const placementStyleCallback = {
     optionsContainer: ({optionsPlacement, style}: {optionsPlacement?: "above" | "below"; style: Record<string, unknown>}) => {
       Object.freeze(style)

--- a/spec/system/haya-select-pagination-spec.js
+++ b/spec/system/haya-select-pagination-spec.js
@@ -31,11 +31,12 @@ describe("HayaSelect pagination", () => {
 
         await systemTest.findByTestID("hayaSelectPaginationRoot", {timeout: 5000})
         await openPaginatedSelect(systemTest)
+        await systemTest.find("[data-class='pagination-ellipsis']", {useBaseSelector: false})
 
         const pageTwo = await findPaginationPageButton(systemTest, 2)
         await systemTest.click(pageTwo)
 
-        await waitForPaginationLabel(systemTest, "Page 2 of 5")
+        await waitForPaginationLabel(systemTest, "Page 2 of 11")
         await waitFor({timeout: 5000}, async () => {
           const texts = await helper.optionTexts()
 
@@ -57,7 +58,7 @@ describe("HayaSelect pagination", () => {
 
         await setPaginationInputValue(systemTest, "4")
 
-        await waitForPaginationLabel(systemTest, "Page 4 of 5")
+        await waitForPaginationLabel(systemTest, "Page 4 of 11")
         await waitFor({timeout: 5000}, async () => {
           const texts = await helper.optionTexts()
 
@@ -76,10 +77,10 @@ describe("HayaSelect pagination", () => {
 
         await systemTest.findByTestID("hayaSelectPaginationRoot", {timeout: 5000})
         await openPaginatedSelect(systemTest)
-        await waitForPaginationLabel(systemTest, "Page 1 of 5")
+        await waitForPaginationLabel(systemTest, "Page 1 of 11")
 
         await clickPaginationSelector(systemTest, "[data-class='pagination-next']")
-        await waitForPaginationLabel(systemTest, "Page 2 of 5")
+        await waitForPaginationLabel(systemTest, "Page 2 of 11")
         await waitFor({timeout: 5000}, async () => {
           const texts = await helper.optionTexts()
 
@@ -89,7 +90,7 @@ describe("HayaSelect pagination", () => {
         })
 
         await clickPaginationSelector(systemTest, "[data-class='pagination-prev']")
-        await waitForPaginationLabel(systemTest, "Page 1 of 5")
+        await waitForPaginationLabel(systemTest, "Page 1 of 11")
         await waitFor({timeout: 5000}, async () => {
           const texts = await helper.optionTexts()
 

--- a/src/select/index.jsx
+++ b/src/select/index.jsx
@@ -1515,17 +1515,35 @@ class HayaSelect extends ShapeComponent {
                 <View
                   dataSet={dataSets[`paginationEllipsis-${item.key}`] ||= {class: "pagination-ellipsis"}}
                   key={item.key}
-                  style={styles.paginationEllipsis ||= {paddingHorizontal: 6}}
+                  style={styles.paginationEllipsis ||= {
+                    alignItems: "center",
+                    flexDirection: "row",
+                    height: 28,
+                    justifyContent: "center",
+                    paddingHorizontal: 6
+                  }}
                 >
-                  <Text
-                    style={styles.paginationEllipsisText ||= {
-                      color: "#64748b",
-                      fontSize: 12,
-                      fontWeight: 600
-                    }}
-                  >
-                    ...
-                  </Text>
+                  <View style={styles.paginationEllipsisDot ||= {
+                    backgroundColor: "#64748b",
+                    borderRadius: 2,
+                    height: 4,
+                    marginHorizontal: 1,
+                    width: 4
+                  }} />
+                  <View style={styles.paginationEllipsisDot ||= {
+                    backgroundColor: "#64748b",
+                    borderRadius: 2,
+                    height: 4,
+                    marginHorizontal: 1,
+                    width: 4
+                  }} />
+                  <View style={styles.paginationEllipsisDot ||= {
+                    backgroundColor: "#64748b",
+                    borderRadius: 2,
+                    height: 4,
+                    marginHorizontal: 1,
+                    width: 4
+                  }} />
                 </View>
               )
             }


### PR DESCRIPTION
## Summary
- render pagination ellipses as React Native views instead of literal text
- expand the pagination example fixture so system tests exercise ellipsis rendering
- update pagination system test expectations and changelog

## Tests
- `npm run lint`
- `npm run typecheck`
- `npm run test:dist`
- `npx expo-doctor`