### PR TITLE
Add mobile bottom sheet options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,4 +49,3 @@
 - Build `example/dist` automatically when running system tests with `SYSTEM_TEST_HOST=dist`.
 - Serialize shared SystemTest usage in system specs to avoid overlapping WebSocket command races.
 - Stabilize placement callback system assertions by waiting for both placement state and updated corner radii.
-- Add a mobile bottom-sheet options view with the `mobileOptionsMode` override prop.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,3 +49,4 @@
 - Build `example/dist` automatically when running system tests with `SYSTEM_TEST_HOST=dist`.
 - Serialize shared SystemTest usage in system specs to avoid overlapping WebSocket command races.
 - Stabilize placement callback system assertions by waiting for both placement state and updated corner radii.
+- Add a mobile bottom-sheet options view with the `mobileOptionsMode` override prop.

--- a/README.md
+++ b/README.md
@@ -76,6 +76,21 @@ The callback receives the current `searchValue`, `page`, and optional `values` w
 
 If `totalCount` and `page` are provided, the options list shows pagination controls with previous/next buttons, a page range around the current page, and a "Page X of Y" label that can be clicked to enter a page number manually.
 
+## Mobile options sheet
+
+HayaSelect opens options in a bottom sheet on mobile-sized screens by default. The sheet is used when the window width is 768px or less on web, iOS, and Android. It keeps the options list scrollable inside the sheet and places the search input at the bottom.
+
+Use `mobileOptionsMode` to override the automatic behavior:
+
+```jsx
+<HayaSelect
+  mobileOptionsMode="never"
+  options={options}
+/>
+```
+
+`mobileOptionsMode` accepts `"auto"` (default), `"always"`, or `"never"`.
+
 # Contributing
 
 Contributions are very welcome! Please refer to guidelines described in the [contributing guide]( https://github.com/expo/expo#contributing).

--- a/changelog.d/mobile-bottom-sheet-options.md
+++ b/changelog.d/mobile-bottom-sheet-options.md
@@ -1,0 +1,1 @@
+- Add a mobile bottom-sheet options view with the `mobileOptionsMode` override prop.

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -1,71 +1,22 @@
 import Text from "@kaspernj/api-maker/build/utils/text"
-import {PortalHost,PortalProvider} from "conjointment"
-import {useEvent} from "expo"
+import {PortalHost, PortalProvider} from "conjointment"
 import OutsideEyeProvider from "outside-eye/build/provider.js"
-import React, {useEffect, useState} from "react"
-import {Button,Platform,SafeAreaView,ScrollView,View} from "react-native"
+import React, {useEffect} from "react"
+import {Platform, SafeAreaView} from "react-native"
 import SystemTestBrowserHelper from "system-testing/build/system-test-browser-helper.js"
 
-import HayaSelectModule,{HayaSelectView} from "./haya-select-module"
-// The example app needs the select component for system testing.
-// @ts-expect-error - the component is authored in JS.
-import HayaSelect from "../src/select/index.jsx"
 import HayaSelectConfiguration from "../src/config.js"
+import {screenForName} from "./screens"
+import {styles} from "./screens/shared"
+
+const currentScreenName = () => {
+  if (Platform.OS !== "web" || typeof window === "undefined") return null
+
+  return new URLSearchParams(window.location.search).get("screen")
+}
 
 export default function App() {
-  const onChangePayload = useEvent(HayaSelectModule, "onChange")
-  const selectOptions = [
-    {value: "one", text: "One"},
-    {value: "two", text: "Two"},
-    {value: "three", text: "Three"}
-  ]
-  const placementAboveOptions = Array.from({length: 25}).map((_, index) => ({
-    value: `placement-above-${index + 1}`,
-    text: `Placement Option ${index + 1}`
-  }))
-  const mobileSheetOptions = Array.from({length: 40}).map((_, index) => ({
-    value: `mobile-sheet-${index + 1}`,
-    text: `Mobile Sheet Option ${index + 1}`
-  }))
-  const rightSelectOptions = selectOptions.map((option) => ({
-    ...option,
-    right: <Text>Right {option.text}</Text>
-  }))
-  const controlledValues = ["one", "two"]
-  const staleValueOptions = [
-    {value: "one", text: "One"},
-    {value: "two", text: "Two"}
-  ]
-  const staleValues = ["one", "missing"]
-  const paginationPageSize = 5
-  const paginationTotalCount = 24
-  const placementStyleCallback = {
-    optionsContainer: ({optionsPlacement, style}: {optionsPlacement?: "above" | "below"; style: Record<string, unknown>}) => {
-      Object.freeze(style)
-
-      if (optionsPlacement === "above") {
-        return {
-          borderBottomLeftRadius: 0,
-          borderBottomRightRadius: 0,
-          borderTopLeftRadius: 14,
-          borderTopRightRadius: 14
-        }
-      }
-
-      return {
-        borderBottomLeftRadius: 14,
-        borderBottomRightRadius: 14,
-        borderTopLeftRadius: 0,
-        borderTopRightRadius: 0
-      }
-    }
-  }
-  const [actionTypeValue, setActionTypeValue] = useState<string | null>(null)
-  const actionTypeOptions = [
-    {value: "email", text: "Email"},
-    {value: "points", text: "Points"},
-    {value: "sms", text: "SMS"}
-  ]
+  const Screen = screenForName(currentScreenName())
 
   useEffect(() => {
     HayaSelectConfiguration.current().setUseTranslate(() => ({
@@ -76,40 +27,14 @@ export default function App() {
       }
     }))
 
-    if (Platform.OS !== "web" || typeof window === "undefined") return;
+    if (Platform.OS !== "web" || typeof window === "undefined") return
 
     const params = new URLSearchParams(window.location.search)
-    if (params.get("systemTest") !== "true") return;
+    if (params.get("systemTest") !== "true") return
 
     const helper = new SystemTestBrowserHelper()
     helper.enableOnBrowser()
   }, [])
-
-  const paginatedOptions = async ({searchValue, page = 1}: {searchValue?: string; page?: number}) => {
-    const availableOptions = Array.from({length: paginationTotalCount}).map((_, index) => ({
-      value: `option-${index + 1}`,
-      text: `Item ${index + 1}`
-    }))
-    const filteredOptions = searchValue
-      ? availableOptions.filter((option) => option.text.toLowerCase().includes(searchValue.toLowerCase()))
-      : availableOptions
-    const startIndex = (page - 1) * paginationPageSize
-    const pageOptions = filteredOptions
-      .slice(startIndex, startIndex + paginationPageSize)
-      .map((option) => ({...option, text: `Page ${page} ${option.text}`}))
-
-    return {
-      options: pageOptions,
-      totalCount: filteredOptions.length,
-      page,
-      pageSize: paginationPageSize
-    }
-  }
-  const controlledOptions = async ({values}: {values?: Array<string>}) => {
-    if (Array.isArray(values)) return {options: []}
-
-    return {options: selectOptions}
-  }
 
   return (
     <PortalProvider>
@@ -120,203 +45,13 @@ export default function App() {
             style={styles.container}
             testID="systemTestingComponent"
           >
-            <ScrollView style={styles.container}>
-              <Text testID="blankText" style={styles.blankText}>
-                {" "}
-              </Text>
-              <Text style={styles.header}>Module API Example</Text>
-              {/*
-                Keep the placement-below select at the top of the ScrollView
-                so its trigger lives near the top of the viewport in CI,
-                regardless of default window height. The placement decision
-                in HayaSelect uses `document.documentElement.scrollTop` and
-                does not track scroll inside this RN ScrollView, so a
-                trigger far down the list otherwise flips to "above" when
-                there isn't enough room below it.
-              */}
-              <Group name="Placement Callback Select Top">
-                <View testID="hayaSelectPlacementBelowRoot">
-                  <HayaSelect
-                    options={selectOptions}
-                    placeholder="Placement below"
-                    styles={placementStyleCallback}
-                  />
-                </View>
-              </Group>
-              <Group name="Constants">
-                <Text>{HayaSelectModule.PI}</Text>
-              </Group>
-              <Group name="Functions">
-                <Text>{HayaSelectModule.hello()}</Text>
-              </Group>
-              <Group name="Async functions">
-                <Button
-                  title="Set value"
-                  onPress={async () => {
-                    await HayaSelectModule.setValueAsync('Hello from JS!');
-                  }}
-                />
-              </Group>
-              <Group name="Events">
-                <Text>{onChangePayload?.value}</Text>
-              </Group>
-              <Group name="Select">
-                <View testID="hayaSelectRoot">
-                  <HayaSelect
-                    options={selectOptions}
-                    placeholder="Pick one"
-                  />
-                </View>
-              </Group>
-              <Group name="Right Option Select">
-                <View testID="hayaSelectRightOptionRoot">
-                  <HayaSelect
-                    options={rightSelectOptions}
-                    placeholder="Pick with right"
-                  />
-                </View>
-              </Group>
-              <Group name="Option Content Select">
-                <View testID="hayaSelectOptionContentRoot">
-                  <HayaSelect
-                    optionContent={({option}) => (
-                      <Text>
-                        Custom {option.text}
-                      </Text>
-                    )}
-                    options={selectOptions}
-                    placeholder="Pick custom"
-                  />
-                </View>
-              </Group>
-              <Group name="Multiple Select">
-                <View testID="hayaSelectMultipleRoot">
-                  <HayaSelect
-                    multiple
-                    options={selectOptions}
-                    placeholder="Pick multiple"
-                  />
-                </View>
-              </Group>
-              <Group name="Close On Change Select">
-                <View testID="hayaSelectCloseOnChangeRoot">
-                  <HayaSelect
-                    onChangeValue={(value) => setActionTypeValue(value)}
-                    options={actionTypeOptions}
-                    placeholder="Pick action"
-                  />
-                  {actionTypeValue === "points" &&
-                    <Text testID="hayaSelectCloseOnChangeDetails">
-                      Points selected
-                    </Text>
-                  }
-                </View>
-              </Group>
-              <Group name="Controlled Values Select">
-                <View testID="hayaSelectControlledValuesRoot">
-                  <HayaSelect
-                    multiple
-                    name="controlled_values"
-                    options={controlledOptions}
-                    placeholder="Pick controlled"
-                    values={controlledValues}
-                  />
-                </View>
-              </Group>
-              <Group name="Stale Values Select">
-                <View testID="hayaSelectStaleValuesRoot">
-                  <HayaSelect
-                    multiple
-                    name="stale_values"
-                    options={staleValueOptions}
-                    placeholder="Pick stale"
-                    values={staleValues}
-                  />
-                </View>
-              </Group>
-              <Group name="Paginated Select">
-                <View testID="hayaSelectPaginationRoot">
-                  <HayaSelect
-                    options={paginatedOptions}
-                    placeholder="Pick a page"
-                    search
-                  />
-                </View>
-              </Group>
-              <Group name="Mobile Sheet Select">
-                <View testID="hayaSelectMobileSheetRoot">
-                  <HayaSelect
-                    options={mobileSheetOptions}
-                    placeholder="Pick mobile sheet"
-                    search
-                  />
-                </View>
-              </Group>
-              <Group name="Views">
-                <HayaSelectView
-                  url="https://www.example.com"
-                  onLoad={({nativeEvent: {url}}) => console.log(`Loaded: ${url}`)}
-                  style={styles.view}
-                />
-              </Group>
-            </ScrollView>
-            <View style={styles.fixedBottomSelectContainer}>
-              <View testID="hayaSelectPlacementAboveRoot">
-                <HayaSelect
-                  options={placementAboveOptions}
-                  placeholder="Placement above"
-                  styles={placementStyleCallback}
-                />
-              </View>
-            </View>
+            <Text testID="blankText" style={styles.blankText}>
+              {" "}
+            </Text>
+            <Screen />
           </SafeAreaView>
         </OutsideEyeProvider>
       </PortalHost>
     </PortalProvider>
-  );
-}
-
-function Group(props: {name: string; children: React.ReactNode}) {
-  return (
-    <View style={styles.group}>
-      <Text style={styles.groupHeader}>{props.name}</Text>
-      {props.children}
-    </View>
-  );
-}
-
-const styles = {
-  header: {
-    fontSize: 30,
-    margin: 20,
-  },
-  groupHeader: {
-    fontSize: 20,
-    marginBottom: 20,
-  },
-  group: {
-    margin: 20,
-    backgroundColor: '#fff',
-    borderRadius: 10,
-    padding: 20,
-  },
-  container: {
-    flex: 1,
-    backgroundColor: '#eee',
-  },
-  view: {
-    flex: 1,
-    height: 200,
-  },
-  blankText: {
-    height: 1,
-    opacity: 0.01,
-    width: 1,
-  },
-  fixedBottomSelectContainer: {
-    bottom: 20,
-    left: 20,
-    position: "absolute",
-    right: 20
-  }
+  )
 }

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -23,6 +23,10 @@ export default function App() {
     value: `placement-above-${index + 1}`,
     text: `Placement Option ${index + 1}`
   }))
+  const mobileSheetOptions = Array.from({length: 40}).map((_, index) => ({
+    value: `mobile-sheet-${index + 1}`,
+    text: `Mobile Sheet Option ${index + 1}`
+  }))
   const rightSelectOptions = selectOptions.map((option) => ({
     ...option,
     right: <Text>Right {option.text}</Text>
@@ -235,6 +239,15 @@ export default function App() {
                   <HayaSelect
                     options={paginatedOptions}
                     placeholder="Pick a page"
+                    search
+                  />
+                </View>
+              </Group>
+              <Group name="Mobile Sheet Select">
+                <View testID="hayaSelectMobileSheetRoot">
+                  <HayaSelect
+                    options={mobileSheetOptions}
+                    placeholder="Pick mobile sheet"
                     search
                   />
                 </View>

--- a/example/screens/basic-select-screen.tsx
+++ b/example/screens/basic-select-screen.tsx
@@ -1,0 +1,19 @@
+import React from "react"
+import {View} from "react-native"
+
+import {Group, HayaSelect, selectOptions, TestScrollView} from "./shared"
+
+export default function BasicSelectScreen() {
+  return (
+    <TestScrollView>
+      <Group name="Select">
+        <View testID="hayaSelectRoot">
+          <HayaSelect
+            options={selectOptions}
+            placeholder="Pick one"
+          />
+        </View>
+      </Group>
+    </TestScrollView>
+  )
+}

--- a/example/screens/close-on-change-screen.tsx
+++ b/example/screens/close-on-change-screen.tsx
@@ -1,0 +1,33 @@
+import React, {useState} from "react"
+import {View} from "react-native"
+
+import {Group, HayaSelect, TestScrollView, Text} from "./shared"
+
+const actionTypeOptions = [
+  {value: "email", text: "Email"},
+  {value: "points", text: "Points"},
+  {value: "sms", text: "SMS"}
+]
+
+export default function CloseOnChangeScreen() {
+  const [actionTypeValue, setActionTypeValue] = useState<string | null>(null)
+
+  return (
+    <TestScrollView>
+      <Group name="Close On Change Select">
+        <View testID="hayaSelectCloseOnChangeRoot">
+          <HayaSelect
+            onChangeValue={(value) => setActionTypeValue(value)}
+            options={actionTypeOptions}
+            placeholder="Pick action"
+          />
+          {actionTypeValue === "points" &&
+            <Text testID="hayaSelectCloseOnChangeDetails">
+              Points selected
+            </Text>
+          }
+        </View>
+      </Group>
+    </TestScrollView>
+  )
+}

--- a/example/screens/controlled-values-screen.tsx
+++ b/example/screens/controlled-values-screen.tsx
@@ -1,0 +1,30 @@
+import React from "react"
+import {View} from "react-native"
+
+import {Group, HayaSelect, selectOptions, TestScrollView} from "./shared"
+
+const controlledValues = ["one", "two"]
+
+const controlledOptions = async ({values}: {values?: Array<string>}) => {
+  if (Array.isArray(values)) return {options: []}
+
+  return {options: selectOptions}
+}
+
+export default function ControlledValuesScreen() {
+  return (
+    <TestScrollView>
+      <Group name="Controlled Values Select">
+        <View testID="hayaSelectControlledValuesRoot">
+          <HayaSelect
+            multiple
+            name="controlled_values"
+            options={controlledOptions}
+            placeholder="Pick controlled"
+            values={controlledValues}
+          />
+        </View>
+      </Group>
+    </TestScrollView>
+  )
+}

--- a/example/screens/filter-select-screen.tsx
+++ b/example/screens/filter-select-screen.tsx
@@ -1,0 +1,20 @@
+import React from "react"
+import {View} from "react-native"
+
+import {Group, HayaSelect, selectOptions, TestScrollView} from "./shared"
+
+export default function FilterSelectScreen() {
+  return (
+    <TestScrollView>
+      <Group name="Filter Select">
+        <View testID="hayaSelectRoot">
+          <HayaSelect
+            options={selectOptions}
+            placeholder="Pick one"
+            search
+          />
+        </View>
+      </Group>
+    </TestScrollView>
+  )
+}

--- a/example/screens/index.tsx
+++ b/example/screens/index.tsx
@@ -1,0 +1,51 @@
+import React from "react"
+
+import BasicSelectScreen from "./basic-select-screen"
+import CloseOnChangeScreen from "./close-on-change-screen"
+import ControlledValuesScreen from "./controlled-values-screen"
+import FilterSelectScreen from "./filter-select-screen"
+import MobileSheetResizeScreen from "./mobile-sheet-resize-screen"
+import MobileSheetSelectScreen from "./mobile-sheet-select-screen"
+import ModuleApiScreen from "./module-api-screen"
+import MultipleClearScreen from "./multiple-clear-screen"
+import MultipleHighlightScreen from "./multiple-highlight-screen"
+import MultipleSelectScreen from "./multiple-select-screen"
+import NoOptionsSelectScreen from "./no-options-select-screen"
+import OptionContentScreen from "./option-content-screen"
+import PaginationChangePageScreen from "./pagination-change-page-screen"
+import PaginationManualEntryScreen from "./pagination-manual-entry-screen"
+import PaginationNextPrevScreen from "./pagination-next-prev-screen"
+import PaginationSelectScreen from "./pagination-select-screen"
+import PlacementCallbackScreen from "./placement-callback-screen"
+import RightOptionScreen from "./right-option-screen"
+import RoundedCornersSelectScreen from "./rounded-corners-select-screen"
+import StaleValuesScreen from "./stale-values-screen"
+
+const screens: Record<string, React.ComponentType> = {
+  "basic-select": BasicSelectScreen,
+  "close-on-change": CloseOnChangeScreen,
+  "controlled-values": ControlledValuesScreen,
+  "filter-select": FilterSelectScreen,
+  "mobile-sheet-resize": MobileSheetResizeScreen,
+  "mobile-sheet-select": MobileSheetSelectScreen,
+  "module-api": ModuleApiScreen,
+  "multiple-clear": MultipleClearScreen,
+  "multiple-highlight": MultipleHighlightScreen,
+  "multiple-select": MultipleSelectScreen,
+  "no-options-select": NoOptionsSelectScreen,
+  "option-content": OptionContentScreen,
+  "pagination-change-page": PaginationChangePageScreen,
+  "pagination-manual-entry": PaginationManualEntryScreen,
+  "pagination-next-prev": PaginationNextPrevScreen,
+  "pagination-select": PaginationSelectScreen,
+  "placement-callback": PlacementCallbackScreen,
+  "right-option": RightOptionScreen,
+  "rounded-corners-select": RoundedCornersSelectScreen,
+  "stale-values": StaleValuesScreen
+}
+
+export const screenForName = (name: string | null) => {
+  if (name && screens[name]) return screens[name]
+
+  return ModuleApiScreen
+}

--- a/example/screens/mobile-sheet-resize-screen.tsx
+++ b/example/screens/mobile-sheet-resize-screen.tsx
@@ -1,0 +1,7 @@
+import React from "react"
+
+import MobileSheetSelectScreen from "./mobile-sheet-select-screen"
+
+export default function MobileSheetResizeScreen() {
+  return <MobileSheetSelectScreen />
+}

--- a/example/screens/mobile-sheet-select-screen.tsx
+++ b/example/screens/mobile-sheet-select-screen.tsx
@@ -1,0 +1,25 @@
+import React from "react"
+import {View} from "react-native"
+
+import {Group, HayaSelect, TestScrollView} from "./shared"
+
+const mobileSheetOptions = Array.from({length: 40}).map((_, index) => ({
+  value: `mobile-sheet-${index + 1}`,
+  text: `Mobile Sheet Option ${index + 1}`
+}))
+
+export default function MobileSheetSelectScreen() {
+  return (
+    <TestScrollView>
+      <Group name="Mobile Sheet Select">
+        <View testID="hayaSelectMobileSheetRoot">
+          <HayaSelect
+            options={mobileSheetOptions}
+            placeholder="Pick mobile sheet"
+            search
+          />
+        </View>
+      </Group>
+    </TestScrollView>
+  )
+}

--- a/example/screens/module-api-screen.tsx
+++ b/example/screens/module-api-screen.tsx
@@ -1,0 +1,41 @@
+import Text from "@kaspernj/api-maker/build/utils/text"
+import {useEvent} from "expo"
+import React from "react"
+import {Button} from "react-native"
+
+import HayaSelectModule, {HayaSelectView} from "../haya-select-module"
+import {Group, styles, TestScrollView} from "./shared"
+
+export default function ModuleApiScreen() {
+  const onChangePayload = useEvent(HayaSelectModule, "onChange")
+
+  return (
+    <TestScrollView>
+      <Text style={styles.header}>Module API Example</Text>
+      <Group name="Constants">
+        <Text>{HayaSelectModule.PI}</Text>
+      </Group>
+      <Group name="Functions">
+        <Text>{HayaSelectModule.hello()}</Text>
+      </Group>
+      <Group name="Async functions">
+        <Button
+          title="Set value"
+          onPress={async () => {
+            await HayaSelectModule.setValueAsync("Hello from JS!")
+          }}
+        />
+      </Group>
+      <Group name="Events">
+        <Text>{onChangePayload?.value}</Text>
+      </Group>
+      <Group name="Views">
+        <HayaSelectView
+          url="https://www.example.com"
+          onLoad={({nativeEvent: {url}}) => console.log(`Loaded: ${url}`)}
+          style={styles.view}
+        />
+      </Group>
+    </TestScrollView>
+  )
+}

--- a/example/screens/multiple-clear-screen.tsx
+++ b/example/screens/multiple-clear-screen.tsx
@@ -1,0 +1,7 @@
+import React from "react"
+
+import MultipleSelectScreen from "./multiple-select-screen"
+
+export default function MultipleClearScreen() {
+  return <MultipleSelectScreen />
+}

--- a/example/screens/multiple-highlight-screen.tsx
+++ b/example/screens/multiple-highlight-screen.tsx
@@ -1,0 +1,7 @@
+import React from "react"
+
+import MultipleSelectScreen from "./multiple-select-screen"
+
+export default function MultipleHighlightScreen() {
+  return <MultipleSelectScreen />
+}

--- a/example/screens/multiple-select-screen.tsx
+++ b/example/screens/multiple-select-screen.tsx
@@ -1,0 +1,20 @@
+import React from "react"
+import {View} from "react-native"
+
+import {Group, HayaSelect, selectOptions, TestScrollView} from "./shared"
+
+export default function MultipleSelectScreen() {
+  return (
+    <TestScrollView>
+      <Group name="Multiple Select">
+        <View testID="hayaSelectMultipleRoot">
+          <HayaSelect
+            multiple
+            options={selectOptions}
+            placeholder="Pick multiple"
+          />
+        </View>
+      </Group>
+    </TestScrollView>
+  )
+}

--- a/example/screens/no-options-select-screen.tsx
+++ b/example/screens/no-options-select-screen.tsx
@@ -1,0 +1,20 @@
+import React from "react"
+import {View} from "react-native"
+
+import {Group, HayaSelect, selectOptions, TestScrollView} from "./shared"
+
+export default function NoOptionsSelectScreen() {
+  return (
+    <TestScrollView>
+      <Group name="No Options Select">
+        <View testID="hayaSelectRoot">
+          <HayaSelect
+            options={selectOptions}
+            placeholder="Pick one"
+            search
+          />
+        </View>
+      </Group>
+    </TestScrollView>
+  )
+}

--- a/example/screens/option-content-screen.tsx
+++ b/example/screens/option-content-screen.tsx
@@ -1,0 +1,24 @@
+import React from "react"
+import {View} from "react-native"
+
+import {Group, HayaSelect, selectOptions, TestScrollView, Text} from "./shared"
+
+export default function OptionContentScreen() {
+  return (
+    <TestScrollView>
+      <Group name="Option Content Select">
+        <View testID="hayaSelectOptionContentRoot">
+          <HayaSelect
+            optionContent={({option}) => (
+              <Text>
+                Custom {option.text}
+              </Text>
+            )}
+            options={selectOptions}
+            placeholder="Pick custom"
+          />
+        </View>
+      </Group>
+    </TestScrollView>
+  )
+}

--- a/example/screens/pagination-change-page-screen.tsx
+++ b/example/screens/pagination-change-page-screen.tsx
@@ -1,0 +1,7 @@
+import React from "react"
+
+import PaginationSelectScreen from "./pagination-select-screen"
+
+export default function PaginationChangePageScreen() {
+  return <PaginationSelectScreen />
+}

--- a/example/screens/pagination-manual-entry-screen.tsx
+++ b/example/screens/pagination-manual-entry-screen.tsx
@@ -1,0 +1,7 @@
+import React from "react"
+
+import PaginationSelectScreen from "./pagination-select-screen"
+
+export default function PaginationManualEntryScreen() {
+  return <PaginationSelectScreen />
+}

--- a/example/screens/pagination-next-prev-screen.tsx
+++ b/example/screens/pagination-next-prev-screen.tsx
@@ -1,0 +1,7 @@
+import React from "react"
+
+import PaginationSelectScreen from "./pagination-select-screen"
+
+export default function PaginationNextPrevScreen() {
+  return <PaginationSelectScreen />
+}

--- a/example/screens/pagination-select-screen.tsx
+++ b/example/screens/pagination-select-screen.tsx
@@ -1,0 +1,44 @@
+import React from "react"
+import {View} from "react-native"
+
+import {Group, HayaSelect, TestScrollView} from "./shared"
+
+const paginationPageSize = 5
+const paginationTotalCount = 24
+
+const paginatedOptions = async ({searchValue, page = 1}: {searchValue?: string; page?: number}) => {
+  const availableOptions = Array.from({length: paginationTotalCount}).map((_, index) => ({
+    value: `option-${index + 1}`,
+    text: `Item ${index + 1}`
+  }))
+  const filteredOptions = searchValue
+    ? availableOptions.filter((option) => option.text.toLowerCase().includes(searchValue.toLowerCase()))
+    : availableOptions
+  const startIndex = (page - 1) * paginationPageSize
+  const pageOptions = filteredOptions
+    .slice(startIndex, startIndex + paginationPageSize)
+    .map((option) => ({...option, text: `Page ${page} ${option.text}`}))
+
+  return {
+    options: pageOptions,
+    totalCount: filteredOptions.length,
+    page,
+    pageSize: paginationPageSize
+  }
+}
+
+export default function PaginationSelectScreen() {
+  return (
+    <TestScrollView>
+      <Group name="Paginated Select">
+        <View testID="hayaSelectPaginationRoot">
+          <HayaSelect
+            options={paginatedOptions}
+            placeholder="Pick a page"
+            search
+          />
+        </View>
+      </Group>
+    </TestScrollView>
+  )
+}

--- a/example/screens/placement-callback-screen.tsx
+++ b/example/screens/placement-callback-screen.tsx
@@ -1,0 +1,36 @@
+import React from "react"
+import {View} from "react-native"
+
+import {Group, HayaSelect, placementStyleCallback, selectOptions, styles, TestScrollView} from "./shared"
+
+const placementAboveOptions = Array.from({length: 25}).map((_, index) => ({
+  value: `placement-above-${index + 1}`,
+  text: `Placement Option ${index + 1}`
+}))
+
+export default function PlacementCallbackScreen() {
+  return (
+    <>
+      <TestScrollView>
+        <Group name="Placement Callback Select Top">
+          <View testID="hayaSelectPlacementBelowRoot">
+            <HayaSelect
+              options={selectOptions}
+              placeholder="Placement below"
+              styles={placementStyleCallback}
+            />
+          </View>
+        </Group>
+      </TestScrollView>
+      <View style={styles.fixedBottomSelectContainer}>
+        <View testID="hayaSelectPlacementAboveRoot">
+          <HayaSelect
+            options={placementAboveOptions}
+            placeholder="Placement above"
+            styles={placementStyleCallback}
+          />
+        </View>
+      </View>
+    </>
+  )
+}

--- a/example/screens/right-option-screen.tsx
+++ b/example/screens/right-option-screen.tsx
@@ -1,0 +1,24 @@
+import React from "react"
+import {View} from "react-native"
+
+import {Group, HayaSelect, selectOptions, TestScrollView, Text} from "./shared"
+
+const rightSelectOptions = selectOptions.map((option) => ({
+  ...option,
+  right: <Text>Right {option.text}</Text>
+}))
+
+export default function RightOptionScreen() {
+  return (
+    <TestScrollView>
+      <Group name="Right Option Select">
+        <View testID="hayaSelectRightOptionRoot">
+          <HayaSelect
+            options={rightSelectOptions}
+            placeholder="Pick with right"
+          />
+        </View>
+      </Group>
+    </TestScrollView>
+  )
+}

--- a/example/screens/rounded-corners-select-screen.tsx
+++ b/example/screens/rounded-corners-select-screen.tsx
@@ -1,0 +1,19 @@
+import React from "react"
+import {View} from "react-native"
+
+import {Group, HayaSelect, selectOptions, TestScrollView} from "./shared"
+
+export default function RoundedCornersSelectScreen() {
+  return (
+    <TestScrollView>
+      <Group name="Rounded Corners Select">
+        <View testID="hayaSelectRoot">
+          <HayaSelect
+            options={selectOptions}
+            placeholder="Pick one"
+          />
+        </View>
+      </Group>
+    </TestScrollView>
+  )
+}

--- a/example/screens/shared.tsx
+++ b/example/screens/shared.tsx
@@ -1,0 +1,90 @@
+import Text from "@kaspernj/api-maker/build/utils/text"
+import React from "react"
+import {ScrollView, View} from "react-native"
+
+// The example app needs the select component for system testing.
+// @ts-expect-error - the component is authored in JS.
+import HayaSelect from "../../src/select/index.jsx"
+
+export {HayaSelect, Text}
+
+export const selectOptions = [
+  {value: "one", text: "One"},
+  {value: "two", text: "Two"},
+  {value: "three", text: "Three"}
+]
+
+export const placementStyleCallback = {
+  optionsContainer: ({optionsPlacement, style}: {optionsPlacement?: "above" | "below"; style: Record<string, unknown>}) => {
+    Object.freeze(style)
+
+    if (optionsPlacement === "above") {
+      return {
+        borderBottomLeftRadius: 0,
+        borderBottomRightRadius: 0,
+        borderTopLeftRadius: 14,
+        borderTopRightRadius: 14
+      }
+    }
+
+    return {
+      borderBottomLeftRadius: 14,
+      borderBottomRightRadius: 14,
+      borderTopLeftRadius: 0,
+      borderTopRightRadius: 0
+    }
+  }
+}
+
+export const styles = {
+  header: {
+    fontSize: 30,
+    margin: 20
+  },
+  groupHeader: {
+    fontSize: 20,
+    marginBottom: 20
+  },
+  group: {
+    margin: 20,
+    backgroundColor: "#fff",
+    borderRadius: 10,
+    padding: 20
+  },
+  container: {
+    flex: 1,
+    backgroundColor: "#eee"
+  },
+  view: {
+    flex: 1,
+    height: 200
+  },
+  blankText: {
+    height: 1,
+    opacity: 0.01,
+    width: 1
+  },
+  fixedBottomSelectContainer: {
+    bottom: 20,
+    left: 20,
+    position: "absolute",
+    right: 20
+  }
+}
+
+export function Group(props: {name: string; children: React.ReactNode}) {
+  return (
+    <View style={styles.group}>
+      <Text style={styles.groupHeader}>{props.name}</Text>
+      {props.children}
+    </View>
+  )
+}
+
+export function TestScrollView(props: {children: React.ReactNode}) {
+  return (
+    <ScrollView style={styles.container}>
+      {props.children}
+    </ScrollView>
+  )
+}

--- a/example/screens/stale-values-screen.tsx
+++ b/example/screens/stale-values-screen.tsx
@@ -1,0 +1,28 @@
+import React from "react"
+import {View} from "react-native"
+
+import {Group, HayaSelect, TestScrollView} from "./shared"
+
+const staleValueOptions = [
+  {value: "one", text: "One"},
+  {value: "two", text: "Two"}
+]
+const staleValues = ["one", "missing"]
+
+export default function StaleValuesScreen() {
+  return (
+    <TestScrollView>
+      <Group name="Stale Values Select">
+        <View testID="hayaSelectStaleValuesRoot">
+          <HayaSelect
+            multiple
+            name="stale_values"
+            options={staleValueOptions}
+            placeholder="Pick stale"
+            values={staleValues}
+          />
+        </View>
+      </Group>
+    </TestScrollView>
+  )
+}

--- a/spec/system/haya-select-pagination-spec.js
+++ b/spec/system/haya-select-pagination-spec.js
@@ -20,7 +20,7 @@ describe("HayaSelect pagination", () => {
     await timeout({errorMessage: "afterEach: timed out closing paginated select", timeout: 30000}, async () => {
       await runSystemTest(async (systemTest) => {
         await closePaginatedSelect(systemTest)
-      })
+      }, {screen: "pagination-change-page"})
     })
   })
 
@@ -43,7 +43,7 @@ describe("HayaSelect pagination", () => {
             throw new Error(`Unexpected first option text: ${texts[0]}`)
           }
         })
-      })
+      }, {screen: "pagination-manual-entry"})
     })
   })
 
@@ -65,7 +65,7 @@ describe("HayaSelect pagination", () => {
             throw new Error(`Unexpected first option text: ${texts[0]}`)
           }
         })
-      })
+      }, {screen: "pagination-next-prev"})
     })
   })
 
@@ -97,7 +97,7 @@ describe("HayaSelect pagination", () => {
             throw new Error(`Unexpected first option text: ${texts[0]}`)
           }
         })
-      })
+      }, {screen: "pagination-select"})
     })
   })
 })

--- a/spec/system/haya-select-render-spec.js
+++ b/spec/system/haya-select-render-spec.js
@@ -208,6 +208,108 @@ describe("HayaSelect", () => {
     })
   })
 
+  it("uses a bottom sheet on mobile-sized screens", async () => {
+    await timeout({errorMessage: "render test timed out: uses a bottom sheet on mobile-sized screens", timeout: 60000}, async () => {
+      await runSystemTest(async (systemTest) => {
+        const driver = systemTest.getDriver()
+        const originalWindowRect = await driver.manage().window().getRect()
+        const helper = new HayaSelectSystemTestHelper({systemTest, testId: "hayaSelectMobileSheetRoot"})
+
+        try {
+          await driver.manage().window().setRect({height: 844, width: 390})
+          await waitFor({timeout: 5000}, async () => {
+            const width = await driver.executeScript("return window.innerWidth")
+
+            if (width > 768) {
+              throw new Error(`Expected mobile viewport width, got: ${width}`)
+            }
+          })
+
+          await systemTest.findByTestID("hayaSelectMobileSheetRoot", {timeout: 5000})
+          await helper.open()
+
+          const optionsContainerSelector = await helper.optionsContainerSelector()
+
+          await systemTest.find(
+            "[data-testid='hayaSelectMobileSheetRoot'] [data-component='haya-select'][data-options-placement='sheet']",
+            {timeout: 5000}
+          )
+
+          await waitFor({timeout: 5000}, async () => {
+            const metrics = await driver.executeScript(`
+              const container = document.querySelector(${JSON.stringify(optionsContainerSelector)})
+              if (!container) throw new Error("Missing mobile options container")
+
+              const rect = container.getBoundingClientRect()
+              return {
+                bottom: Math.round(window.innerHeight - rect.bottom),
+                height: rect.height,
+                windowHeight: window.innerHeight
+              }
+            `)
+            const expectedHeight = metrics.windowHeight * 0.8
+
+            if (Math.abs(metrics.height - expectedHeight) > 8) {
+              throw new Error(`Expected sheet height near 80vh, got: ${metrics.height} of ${metrics.windowHeight}`)
+            }
+
+            if (Math.abs(metrics.bottom) > 2) {
+              throw new Error(`Expected sheet to be anchored to bottom, got bottom offset: ${metrics.bottom}`)
+            }
+          })
+
+          await driver.executeScript("window.scrollTo(0, 500)")
+          await waitFor({timeout: 5000}, async () => {
+            const openOptions = await systemTest.all(optionsContainerSelector, {timeout: 0, useBaseSelector: false, visible: true})
+
+            if (openOptions.length === 0) {
+              throw new Error("Expected mobile sheet to stay open after page scroll")
+            }
+          })
+
+          await driver.executeScript(`
+            const scrollView = document.querySelector("[data-class='mobile-options-scroll-view']")
+            if (!scrollView) throw new Error("Missing mobile options scroll view")
+            scrollView.scrollTop = scrollView.scrollHeight
+            scrollView.dispatchEvent(new Event("scroll", {bubbles: true}))
+          `)
+
+          await systemTest.interact(
+            {selector: `${optionsContainerSelector} [data-class='search-text-input']`, useBaseSelector: false},
+            "sendKeys",
+            Key.chord(Key.CONTROL, "a"),
+            Key.BACK_SPACE,
+            "40"
+          )
+
+          await waitFor({timeout: 5000}, async () => {
+            const texts = await helper.optionTexts()
+
+            if (texts.length !== 1 || !texts[0].includes("Mobile Sheet Option 40")) {
+              throw new Error(`Unexpected mobile sheet filtered options: ${texts.join(", ")}`)
+            }
+          })
+
+          await helper.selectOption({value: "mobile-sheet-40"})
+
+          await waitFor({timeout: 5000}, async () => {
+            const currentSelected = await systemTest.find(
+              "[data-testid='hayaSelectMobileSheetRoot'] [data-class='current-selected']",
+              {timeout: 0}
+            )
+            const text = (await currentSelected.getText()).trim()
+
+            if (!text.includes("Mobile Sheet Option 40")) {
+              throw new Error(`Expected selected mobile sheet option, got: ${text}`)
+            }
+          })
+        } finally {
+          await driver.manage().window().setRect(originalWindowRect)
+        }
+      })
+    })
+  })
+
   it("highlights selected options in multiple select", async () => {
     await timeout({errorMessage: "render test timed out: highlights selected options in multiple select", timeout: 30000}, async () => {
       await runSystemTest(async (systemTest) => {

--- a/spec/system/haya-select-render-spec.js
+++ b/spec/system/haya-select-render-spec.js
@@ -13,7 +13,7 @@ describe("HayaSelect", () => {
     await timeout({errorMessage: "render test timed out: renders in the example app", timeout: 30000}, async () => {
       await runSystemTest(async (systemTest) => {
         await systemTest.findByTestID("hayaSelectRoot", {timeout: 5000})
-      })
+      }, {screen: "basic-select"})
     })
   })
 
@@ -34,7 +34,7 @@ describe("HayaSelect", () => {
         })
 
         await helper.close()
-      })
+      }, {screen: "option-content"})
     })
   })
 
@@ -55,7 +55,7 @@ describe("HayaSelect", () => {
         })
 
         await helper.close()
-      })
+      }, {screen: "right-option"})
     })
   })
 
@@ -75,7 +75,7 @@ describe("HayaSelect", () => {
             throw new Error("Expected points details to render")
           }
         })
-      })
+      }, {screen: "close-on-change"})
     })
   })
 
@@ -99,7 +99,7 @@ describe("HayaSelect", () => {
           throw new Error(`Expected chip text to include 'One', got: ${text}`)
         }
       })
-    })
+    }, {screen: "stale-values"})
   })
 
   it("renders hidden input for controlled values without current options", async () => {
@@ -122,7 +122,7 @@ describe("HayaSelect", () => {
           throw new Error(`Expected hidden input name to be 'controlled_values[]', got: ${names.join(", ")}`)
         }
       })
-    })
+    }, {screen: "controlled-values"})
   })
 
   it("filters options when searching", async () => {
@@ -163,7 +163,7 @@ describe("HayaSelect", () => {
         })
 
         await helper.close()
-      })
+      }, {screen: "filter-select"})
     })
   })
 
@@ -204,7 +204,7 @@ describe("HayaSelect", () => {
         })
 
         await helper.close()
-      })
+      }, {screen: "no-options-select"})
     })
   })
 
@@ -306,7 +306,7 @@ describe("HayaSelect", () => {
         } finally {
           await driver.manage().window().setRect(originalWindowRect)
         }
-      })
+      }, {screen: "mobile-sheet-select"})
     })
   })
 
@@ -354,7 +354,7 @@ describe("HayaSelect", () => {
         } finally {
           await driver.manage().window().setRect(originalWindowRect)
         }
-      })
+      }, {screen: "mobile-sheet-resize"})
     })
   })
 
@@ -409,7 +409,7 @@ describe("HayaSelect", () => {
         await helper.selectOption({value: "two"})
 
         await helper.close()
-      })
+      }, {screen: "multiple-highlight"})
     })
   })
 
@@ -532,7 +532,7 @@ describe("HayaSelect", () => {
             throw new Error(`Expected placeholder, got: ${text}`)
           }
         })
-      })
+      }, {screen: "multiple-clear"})
     })
   })
 
@@ -614,7 +614,7 @@ describe("HayaSelect", () => {
         expect(finalRadii.topRight).not.toBe("0px")
         expect(finalRadii.bottomLeft).not.toBe("0px")
         expect(finalRadii.bottomRight).not.toBe("0px")
-      })
+      }, {screen: "rounded-corners-select"})
     })
   })
 
@@ -688,7 +688,7 @@ describe("HayaSelect", () => {
         expect(abovePlacementAndRadii.bottomLeft).toBe("0px")
         expect(abovePlacementAndRadii.bottomRight).toBe("0px")
         await aboveHelper.close()
-      })
+      }, {screen: "placement-callback"})
     })
   })
 

--- a/spec/system/haya-select-render-spec.js
+++ b/spec/system/haya-select-render-spec.js
@@ -310,6 +310,54 @@ describe("HayaSelect", () => {
     })
   })
 
+  it("repositions an open sheet after resizing out of mobile width", async () => {
+    await timeout({errorMessage: "render test timed out: repositions an open sheet after resizing out of mobile width", timeout: 60000}, async () => {
+      await runSystemTest(async (systemTest) => {
+        const driver = systemTest.getDriver()
+        const originalWindowRect = await driver.manage().window().getRect()
+        const helper = new HayaSelectSystemTestHelper({systemTest, testId: "hayaSelectMobileSheetRoot"})
+
+        try {
+          await driver.manage().window().setRect({height: 844, width: 390})
+          await systemTest.findByTestID("hayaSelectMobileSheetRoot", {timeout: 5000})
+          await helper.open()
+
+          await systemTest.find(
+            "[data-testid='hayaSelectMobileSheetRoot'] [data-component='haya-select'][data-options-placement='sheet']",
+            {timeout: 5000}
+          )
+
+          await driver.manage().window().setRect({height: 844, width: 1280})
+          await waitFor({timeout: 5000}, async () => {
+            const state = await driver.executeScript(`
+              const root = document.querySelector("[data-testid='hayaSelectMobileSheetRoot'] [data-component='haya-select']")
+              const bodyOverflow = document.body.style.overflow
+              const documentOverflow = document.documentElement.style.overflow
+
+              return {
+                bodyOverflow,
+                documentOverflow,
+                optionsPlacement: root && root.getAttribute("data-options-placement")
+              }
+            `)
+
+            if (!["above", "below"].includes(state.optionsPlacement)) {
+              throw new Error(`Expected desktop placement after resize, got: ${state.optionsPlacement}`)
+            }
+
+            if (state.bodyOverflow || state.documentOverflow) {
+              throw new Error(`Expected unlocked document scroll, got body=${state.bodyOverflow} document=${state.documentOverflow}`)
+            }
+          })
+
+          await helper.close()
+        } finally {
+          await driver.manage().window().setRect(originalWindowRect)
+        }
+      })
+    })
+  })
+
   it("highlights selected options in multiple select", async () => {
     await timeout({errorMessage: "render test timed out: highlights selected options in multiple select", timeout: 30000}, async () => {
       await runSystemTest(async (systemTest) => {

--- a/spec/system/system-test-lifecycle.js
+++ b/spec/system/system-test-lifecycle.js
@@ -43,12 +43,26 @@ let runQueue = Promise.resolve()
 /** @param {unknown} error */
 const dismissToListenerMissingError = (error) => error instanceof Error && error.message.includes("No listener registered for command event: dismissTo")
 
+/** @typedef {{screen?: string}} RunSystemTestOptions */
+
+/**
+ * @param {string} rootPath System test root path.
+ * @param {string|undefined} screen Example screen name.
+ * @returns {string} Root path with the example screen query parameter.
+ */
+const rootPathForScreen = (rootPath, screen) => {
+  if (!screen) return rootPath
+
+  return `${rootPath}&screen=${encodeURIComponent(screen)}`
+}
+
 /**
  * @param {import("system-testing/build/system-test.js").default} systemTest
+ * @param {RunSystemTestOptions} [options] Run options.
  * @returns {Promise<void>}
  */
-const initializeSystemTestRun = async (systemTest) => {
-  const rootPath = systemTest.getRootPath()
+const initializeSystemTestRun = async (systemTest, {screen} = {}) => {
+  const rootPath = rootPathForScreen(systemTest.getRootPath(), screen)
 
   await systemTest.driverVisit(rootPath)
   await systemTest.waitForClientWebSocket()
@@ -58,15 +72,16 @@ const initializeSystemTestRun = async (systemTest) => {
 /**
  * Runs system test callbacks sequentially to avoid overlapping WebSocket commands.
  * @param {(systemTest: import("system-testing/build/system-test.js").default) => Promise<void>} callback
+ * @param {RunSystemTestOptions} [options] Run options.
  * @returns {Promise<void>}
  */
-export const runSystemTest = async (callback) => {
+export const runSystemTest = async (callback, options = {}) => {
   const run = async () => {
     const systemTest = SystemTest.current(systemTestArgs)
 
     for (let attemptNumber = 1; attemptNumber <= 3; attemptNumber++) {
       try {
-        await initializeSystemTestRun(systemTest)
+        await initializeSystemTestRun(systemTest, options)
         await callback(systemTest)
         return
       } catch (error) {

--- a/src/select/index.jsx
+++ b/src/select/index.jsx
@@ -21,6 +21,7 @@ import usePressOutside from "outside-eye/build/use-press-outside"
 
 const styles = {}
 const dataSets = {}
+const MOBILE_OPTIONS_MAX_WIDTH = 768
 
 /**
  * @typedef {object} HayaSelectToggleOption
@@ -61,6 +62,7 @@ const dataSets = {}
  * @property {boolean} [debug]
  * @property {import("react").ReactNode} [id]
  * @property {object} [model]
+ * @property {"auto"|"always"|"never"} [mobileOptionsMode]
  * @property {boolean} [multiple]
  * @property {string} [name]
  * @property {function(): import("react").ReactNode} [noOptionsText]
@@ -102,7 +104,7 @@ const dataSets = {}
  * @property {number|null} pageSize
  * @property {boolean} opened
  * @property {HayaSelectLayout|null} optionsContainerLayout
- * @property {"above"|"below"|undefined} optionsPlacement
+ * @property {"above"|"below"|"sheet"|undefined} optionsPlacement
  * @property {number|undefined} optionsTop
  * @property {"hidden"|"visible"|undefined} optionsVisibility
  * @property {number|undefined|null} optionsWidth
@@ -171,7 +173,7 @@ function layoutHasPosition(layout) {
 /**
  * @typedef {object} HayaSelectStylingContext
  * @property {boolean} opened
- * @property {"above"|"below"|undefined} optionsPlacement
+ * @property {"above"|"below"|"sheet"|undefined} optionsPlacement
  * @property {HayaSelectState} state
  * @property {Record<string, any>} style
  */
@@ -199,6 +201,7 @@ const nameForComponentWithMultiple = (component) => {
 class HayaSelect extends ShapeComponent {
   static defaultProps = {
     debug: false,
+    mobileOptionsMode: "auto",
     multiple: false,
     noOptionsText: null,
     onBlur: null,
@@ -221,6 +224,7 @@ class HayaSelect extends ShapeComponent {
     debug: PropTypes.bool.isRequired,
     id: PropTypes.node,
     model: PropTypes.object,
+    mobileOptionsMode: PropTypes.oneOf(["auto", "always", "never"]),
     multiple: PropTypes.bool.isRequired,
     name: PropTypes.string,
     noOptionsText: PropTypes.func,
@@ -263,10 +267,13 @@ class HayaSelect extends ShapeComponent {
   })
 
   callOptionsPositionAboveIfOutsideScreen = false
+  bodyScrollLocked = false
   endOfSelectRef = createRef()
   latestLoadOptionsRequestId = 0
   optionsContainerRef = createRef()
   pageInputRef = createRef()
+  previousBodyOverflow = undefined
+  previousDocumentOverflow = undefined
   searchTextValue = ""
   searchTextInputRef = createRef()
   selectContainerRef = createRef()
@@ -404,6 +411,14 @@ class HayaSelect extends ShapeComponent {
 
   /** @returns {number} */
   getActivePage = () => this.s.page || 1
+
+  /** @returns {boolean} */
+  isMobileOptionsSheet() {
+    if (this.p.mobileOptionsMode == "always") return true
+    if (this.p.mobileOptionsMode == "never") return false
+
+    return Dimensions.get("window").width <= MOBILE_OPTIONS_MAX_WIDTH
+  }
 
   /**
    * @param {Array<HayaSelectOption>|HayaSelectOptionsResult} result
@@ -549,6 +564,11 @@ class HayaSelect extends ShapeComponent {
     }
   }
 
+  /** @returns {void} */
+  componentWillUnmount() {
+    this.unlockBodyScroll()
+  }
+
   /** @returns {import("react").ReactNode} */
   render() {
     const {endOfSelectRef} = this.tt
@@ -558,6 +578,7 @@ class HayaSelect extends ShapeComponent {
     const {opened, optionsPlacement} = this.s
     const currentOptions = this.getCurrentOptions()
     const id = idForComponent(this)
+    const mobileOptionsSheet = this.isMobileOptionsSheet()
 
     const selectContainerStyleActual = {...this.stylingFor("selectContainer", {
       flexDirection: "row",
@@ -573,7 +594,7 @@ class HayaSelect extends ShapeComponent {
       paddingLeft: 5
     }, [transparent])}
 
-    if (opened) {
+    if (opened && !mobileOptionsSheet) {
       // Prevent select from changing size once the content is replaced with search text once opened
       selectContainerStyleActual.height = this.s.height
 
@@ -621,23 +642,10 @@ class HayaSelect extends ShapeComponent {
             dataSet={this.currentSelectedDataSet ||= {class: "current-selected"}}
             style={this.stylingFor("currentSelected", this.currentSelectedStyle ||= {flex: 1, flexWrap: "wrap", overflow: "hidden"})}
           >
-            {opened &&
-              <TextInput
-                dataSet={this.searchTextInputDataSet ||= {class: "search-text-input"}}
-                onChangeText={this.tt.onChangeSearchText}
-                placeholder={this.translate(".search_dot_dot_dot")}
-                ref={this.tt.searchTextInputRef}
-                style={this.stylingFor("searchTextInput", this.searchTextInputStyle ||= {
-                  width: "100%",
-                  borderWidth: 0,
-                  outline: Platform.OS == "web" ? "none" : undefined,
-                  padding: 0
-                })}
-                defaultValue={this.searchTextValue}
-                {...this.p.searchTextInputProps}
-              />
+            {opened && !mobileOptionsSheet &&
+              this.searchTextInput()
             }
-            {!opened &&
+            {(!opened || mobileOptionsSheet) &&
               <>
                 {currentOptions.length == 0 &&
                   <Text numberOfLines={1} style={this.stylingFor("nothingSelected", this.nothingSelectedStyle ||= {color: "grey"})}>
@@ -727,6 +735,27 @@ class HayaSelect extends ShapeComponent {
           </View>
         }
       </View>
+    )
+  }
+
+  /** @returns {import("react").ReactNode} */
+  searchTextInput() {
+    return (
+      <TextInput
+        dataSet={this.searchTextInputDataSet ||= {class: "search-text-input"}}
+        defaultValue={this.searchTextValue}
+        onChangeText={this.tt.onChangeSearchText}
+        placeholder={this.translate(".search_dot_dot_dot")}
+        ref={this.tt.searchTextInputRef}
+        style={this.stylingFor("searchTextInput", this.searchTextInputStyle ||= {
+          width: "100%",
+          borderWidth: 0,
+          outline: Platform.OS == "web" ? "none" : undefined,
+          padding: 0
+        })}
+        testID="haya-select-search-input"
+        {...this.p.searchTextInputProps}
+      />
     )
   }
 
@@ -888,7 +917,11 @@ class HayaSelect extends ShapeComponent {
     this.windowHeight = window.height
 
     if (this.s.opened) {
-      this.measureNativeSelectLayouts()
+      if (this.isMobileOptionsSheet()) {
+        this.setOptionsPositionSheet()
+      } else {
+        this.measureNativeSelectLayouts()
+      }
     }
   }
 
@@ -1002,6 +1035,7 @@ class HayaSelect extends ShapeComponent {
     const closedOptions = options || this.getCurrentOptions()
     if (this.isDebugEnabled()) this.debugLog("closeOptions", {closedOptionsCount: closedOptions?.length || 0})
     this.callOptionsPositionAboveIfOutsideScreen = false
+    this.unlockBodyScroll()
 
     this.setState(
       {
@@ -1066,19 +1100,22 @@ class HayaSelect extends ShapeComponent {
 
   /** @returns {void} */
   openOptions() {
+    const mobileOptionsSheet = this.isMobileOptionsSheet()
+
     if (this.isDebugEnabled()) this.debugLog("openOptions", {
       currentOptionsCount: this.getCurrentOptions()?.length || 0,
+      mobileOptionsSheet,
       searchEnabled: this.p.search
     })
     this.searchTextValue = ""
-    this.callOptionsPositionAboveIfOutsideScreen = true
+    this.callOptionsPositionAboveIfOutsideScreen = !mobileOptionsSheet
     this.setState(
       {
-        height: this.s.selectContainerLayout.height,
+        height: mobileOptionsSheet ? null : this.s.selectContainerLayout?.height,
         opened: true,
-        optionsPlacement: "below",
-        optionsVisibility: "hidden",
-        optionsWidth: this.s.endOfSelectLayout?.width,
+        optionsPlacement: mobileOptionsSheet ? "sheet" : "below",
+        optionsVisibility: mobileOptionsSheet ? "visible" : "hidden",
+        optionsWidth: mobileOptionsSheet ? undefined : this.s.endOfSelectLayout?.width,
         page: 1,
         pageInputFocused: false,
         pageInputValue: "1",
@@ -1086,9 +1123,14 @@ class HayaSelect extends ShapeComponent {
         scrollTop: Platform.OS == "web" ? document.documentElement.scrollTop : null
       },
       () => {
-        this.measureNativeSelectLayouts()
+        if (mobileOptionsSheet) {
+          this.lockBodyScroll()
+        } else {
+          this.measureNativeSelectLayouts()
+          this.focusTextInput()
+        }
+
         this.resetSearchTextInput()
-        this.focusTextInput()
         this.loadOptions({page: 1})
       }
     )
@@ -1100,10 +1142,42 @@ class HayaSelect extends ShapeComponent {
   focusTextInput = () => digg(this.tt.searchTextInputRef, "current")?.focus()
 
   /** @returns {void} */
+  lockBodyScroll() {
+    if (Platform.OS != "web" || typeof document == "undefined" || this.bodyScrollLocked) return
+
+    this.previousBodyOverflow = document.body?.style.overflow
+    this.previousDocumentOverflow = document.documentElement?.style.overflow
+
+    if (document.body) document.body.style.overflow = "hidden"
+    if (document.documentElement) document.documentElement.style.overflow = "hidden"
+
+    this.bodyScrollLocked = true
+  }
+
+  /** @returns {void} */
+  unlockBodyScroll() {
+    if (Platform.OS != "web" || typeof document == "undefined" || !this.bodyScrollLocked) return
+
+    if (document.body) document.body.style.overflow = this.previousBodyOverflow || ""
+    if (document.documentElement) document.documentElement.style.overflow = this.previousDocumentOverflow || ""
+
+    this.previousBodyOverflow = undefined
+    this.previousDocumentOverflow = undefined
+    this.bodyScrollLocked = false
+  }
+
+  /** @returns {void} */
   setOptionsPosition() {
     if (!this.isActive()) {
       return // Debounce after un-mount handeling.
     }
+
+    if (this.isMobileOptionsSheet()) {
+      this.setOptionsPositionSheet()
+      return
+    }
+
+    this.unlockBodyScroll()
 
     if (this.isDebugEnabled()) this.debugLog("setOptionsPosition")
     this.callOptionsPositionAboveIfOutsideScreen = true
@@ -1113,6 +1187,10 @@ class HayaSelect extends ShapeComponent {
   /** @returns {void} */
   setOptionsPositionAboveIfOutsideScreen() {
     if (!this.s.opened) return
+    if (this.isMobileOptionsSheet()) {
+      this.setOptionsPositionSheet()
+      return
+    }
 
     const {windowHeight} = this.tt
     const {optionsContainerLayout, selectContainerLayout} = this.s
@@ -1140,6 +1218,21 @@ class HayaSelect extends ShapeComponent {
       if (this.isDebugEnabled()) this.debugLog("setOptionsPositionAboveIfOutsideScreen", {placement: "below"})
       this.s.optionsVisibility = "visible"
     }
+  }
+
+  /** @returns {void} */
+  setOptionsPositionSheet() {
+    if (!this.s.opened) return
+
+    this.lockBodyScroll()
+
+    this.setState({
+      height: null,
+      opened: true,
+      optionsPlacement: "sheet",
+      optionsVisibility: "visible",
+      optionsWidth: undefined
+    })
   }
 
   /** @returns {void} */
@@ -1192,6 +1285,8 @@ class HayaSelect extends ShapeComponent {
     if (this.s.opened) {
       this.s.scrollLeft = Platform.OS == "web" ? document.documentElement.scrollLeft : null
       this.s.scrollTop = Platform.OS == "web" ? document.documentElement.scrollTop : null
+      if (this.isMobileOptionsSheet()) return
+
       this.setOptionsPosition()
     }
   }
@@ -1205,6 +1300,17 @@ class HayaSelect extends ShapeComponent {
     if (this.s.opened) {
       this.closeOptions()
     }
+  }
+
+  /**
+   * @param {import("react").SyntheticEvent} event Press event.
+   * @returns {void}
+   */
+  onMobileOptionsBackdropPress = (event) => {
+    event.preventDefault()
+    event.stopPropagation()
+
+    this.closeOptions()
   }
 
   /** @returns {number|null} */
@@ -1544,10 +1650,101 @@ class HayaSelect extends ShapeComponent {
     )
   }
 
+  /**
+   * @param {{id: string|number, optionsContent: import("react").ReactNode}} args Mobile sheet content.
+   * @returns {import("react").ReactNode}
+   */
+  mobileOptionsContainer({id, optionsContent}) {
+    const sheetHeight = Math.max(Math.round(Dimensions.get("window").height * 0.8), 240)
+    const sheetStyle = this.stylingFor("optionsContainer", {
+      position: "absolute",
+      zIndex: 100000,
+      elevation: 100000,
+      left: 0,
+      right: 0,
+      bottom: 0,
+      height: sheetHeight,
+      maxHeight: sheetHeight,
+      backgroundColor: "#fff",
+      borderTopColor: "#cbd5e1",
+      borderTopLeftRadius: 18,
+      borderTopRightRadius: 18,
+      borderTopWidth: 1,
+      overflow: "hidden",
+      visibility: this.s.optionsVisibility
+    }, [sheetHeight, this.s.optionsVisibility])
+
+    return (
+      <View
+        dataSet={this.mobileOptionsOverlayDataSet ||= {class: "mobile-options-overlay"}}
+        style={this.stylingFor("mobileOptionsOverlay", styles.mobileOptionsOverlay ||= {
+          position: Platform.OS == "web" ? "fixed" : "absolute",
+          top: 0,
+          right: 0,
+          bottom: 0,
+          left: 0,
+          zIndex: 99999,
+          elevation: 99999
+        })}
+        testID="haya-select-mobile-options-overlay"
+      >
+        <Pressable
+          dataSet={this.mobileOptionsBackdropDataSet ||= {class: "mobile-options-backdrop"}}
+          onPress={this.tt.onMobileOptionsBackdropPress}
+          style={this.stylingFor("mobileOptionsBackdrop", styles.mobileOptionsBackdrop ||= {
+            position: "absolute",
+            top: 0,
+            right: 0,
+            bottom: 0,
+            left: 0,
+            backgroundColor: "rgba(15, 23, 42, 0.32)"
+          })}
+          testID="haya-select-mobile-options-backdrop"
+        />
+        <View
+          dataSet={this.cache(
+            "mobileOptionsContainerDataSet",
+            {class: "options-container", id, role: "dialog", optionsPlacement: "sheet", optionsVisibility: this.s.optionsVisibility || "hidden"},
+            [id, this.s.optionsVisibility]
+          )}
+          onLayout={this.tt.onOptionsContainerLayout}
+          ref={this.tt.optionsContainerRef}
+          style={sheetStyle}
+          testID="haya-select-mobile-options-container"
+        >
+          <ScrollView
+            dataSet={this.mobileOptionsScrollViewDataSet ||= {class: "mobile-options-scroll-view"}}
+            keyboardShouldPersistTaps="handled"
+            nestedScrollEnabled
+            style={this.stylingFor("mobileOptionsScrollView", styles.mobileOptionsScrollView ||= {flex: 1})}
+            testID="haya-select-mobile-options-scroll-view"
+          >
+            {optionsContent}
+          </ScrollView>
+          <View
+            dataSet={this.mobileOptionsSearchContainerDataSet ||= {class: "mobile-options-search-container"}}
+            style={this.stylingFor("mobileOptionsSearchContainer", styles.mobileOptionsSearchContainer ||= {
+              borderTopColor: "#cbd5e1",
+              borderTopWidth: 1,
+              paddingBottom: 14,
+              paddingLeft: 14,
+              paddingRight: 14,
+              paddingTop: 10
+            })}
+            testID="haya-select-mobile-options-search-container"
+          >
+            {this.searchTextInput()}
+          </View>
+        </View>
+      </View>
+    )
+  }
+
   /** @returns {import("react").ReactNode|null} */
   optionsContainer() {
     const {selectContainerLayout, loadedOptions, endOfSelectLayout, optionsContainerLayout, optionsPlacement, optionsVisibility} = this.s
     let left, top
+    const id = idForComponent(this)
     const optionsContent = (
       <>
         {loadedOptions?.map((loadedOption) =>
@@ -1574,6 +1771,10 @@ class HayaSelect extends ShapeComponent {
         {this.paginationControls()}
       </>
     )
+
+    if (this.isMobileOptionsSheet()) {
+      return this.mobileOptionsContainer({id, optionsContent})
+    }
 
     let style = {
       position: "absolute",
@@ -1646,8 +1847,6 @@ class HayaSelect extends ShapeComponent {
     }
 
     style = this.stylingFor("optionsContainer", style, [left, top, style.visibility, style.width])
-
-    const id = idForComponent(this)
 
     return (
       <View

--- a/src/select/index.jsx
+++ b/src/select/index.jsx
@@ -562,6 +562,8 @@ class HayaSelect extends ShapeComponent {
       if (this.isDebugEnabled()) this.debugLog("componentDidUpdate", {syncingKeys: Object.keys(newState)})
       this.s.toggled = newState.toggled
     }
+
+    this.syncOptionsPlacementWithMode()
   }
 
   /** @returns {void} */
@@ -917,11 +919,7 @@ class HayaSelect extends ShapeComponent {
     this.windowHeight = window.height
 
     if (this.s.opened) {
-      if (this.isMobileOptionsSheet()) {
-        this.setOptionsPositionSheet()
-      } else {
-        this.measureNativeSelectLayouts()
-      }
+      this.syncOptionsPlacementWithMode()
     }
   }
 
@@ -1185,6 +1183,24 @@ class HayaSelect extends ShapeComponent {
   }
 
   /** @returns {void} */
+  syncOptionsPlacementWithMode() {
+    if (!this.s.opened) return
+
+    if (this.isMobileOptionsSheet()) {
+      if (this.s.optionsPlacement != "sheet") this.setOptionsPositionSheet()
+      return
+    }
+
+    if (this.s.optionsPlacement == "sheet") {
+      this.setOptionsPositionBelow()
+      return
+    }
+
+    this.unlockBodyScroll()
+    this.measureNativeSelectLayouts()
+  }
+
+  /** @returns {void} */
   setOptionsPositionAboveIfOutsideScreen() {
     if (!this.s.opened) return
     if (this.isMobileOptionsSheet()) {
@@ -1241,6 +1257,7 @@ class HayaSelect extends ShapeComponent {
 
     const {endOfSelectLayout} = this.s
     if (this.isDebugEnabled()) this.debugLog("setOptionsPositionAbove")
+    this.unlockBodyScroll()
 
     this.setState(
       {
@@ -1258,6 +1275,7 @@ class HayaSelect extends ShapeComponent {
     if (!this.s.opened) return
 
     if (this.isDebugEnabled()) this.debugLog("setOptionsPositionBelow")
+    this.unlockBodyScroll()
     this.setState(
       {
         opened: true,
@@ -1745,6 +1763,7 @@ class HayaSelect extends ShapeComponent {
     const {selectContainerLayout, loadedOptions, endOfSelectLayout, optionsContainerLayout, optionsPlacement, optionsVisibility} = this.s
     let left, top
     const id = idForComponent(this)
+    const desktopOptionsPlacement = optionsPlacement == "sheet" ? "below" : optionsPlacement
     const optionsContent = (
       <>
         {loadedOptions?.map((loadedOption) =>
@@ -1795,7 +1814,7 @@ class HayaSelect extends ShapeComponent {
     } else if (!this.p.optionsAbsolute) {
       style.left = 0
       style.bottom = 0
-    } else if (optionsPlacement == "below") {
+    } else if (desktopOptionsPlacement == "below") {
       if (Platform.OS == "web") {
         // onLayout top value is sometimes negative so use browser JS to get it instead
         top = digg(this.tt.endOfSelectRef.current.getBoundingClientRect(), "top") + document.documentElement.scrollTop + 1
@@ -1817,7 +1836,7 @@ class HayaSelect extends ShapeComponent {
         style.top = 0
         style.visibility = "hidden"
       }
-    } else if (optionsPlacement == "above") {
+    } else if (desktopOptionsPlacement == "above") {
       if (Platform.OS == "web") {
         // onLayout top value is sometimes negative so use browser JS to get it instead
         top = digg(this.tt.selectContainerRef.current.getBoundingClientRect(), "top") + document.documentElement.scrollTop
@@ -1838,7 +1857,7 @@ class HayaSelect extends ShapeComponent {
         style.visibility = "hidden"
       }
     } else {
-      throw new Error(`Unkonwn options placement: ${optionsPlacement}`)
+      throw new Error(`Unkonwn options placement: ${desktopOptionsPlacement}`)
     }
 
     if (Platform.OS != "web") {


### PR DESCRIPTION
## Summary
- Add a mobile bottom-sheet options view for mobile-sized web, iOS, and Android windows.
- Add mobileOptionsMode="auto|always|never" to control the sheet behavior.
- Keep options scrollable inside the sheet and move the search input to the bottom without auto-focusing it.

## Tests
- npm run lint
- npm run typecheck
- npm run test:dist
