### PR TITLE
Align mobile sheet options to bottom

### DIFF
--- a/changelog.d/mobile-sheet-bottom-align.md
+++ b/changelog.d/mobile-sheet-bottom-align.md
@@ -1,1 +1,1 @@
-- Align mobile sheet options to the bottom of the options area, make filtered sheets shrink to content, add thumb-friendly mobile option padding, expose stable test IDs for select internals, and remove the sheet's top border.
+- Align mobile sheet options to the bottom of the options area, make filtered sheets shrink to content, add thumb-friendly mobile option padding, expose stable test IDs for select internals, remove the sheet's top border, and use a responder backdrop that avoids pointer cursor styling.

--- a/changelog.d/mobile-sheet-bottom-align.md
+++ b/changelog.d/mobile-sheet-bottom-align.md
@@ -1,1 +1,1 @@
-- Align mobile sheet options to the bottom of the options area and remove the sheet's top border.
+- Align mobile sheet options to the bottom of the options area, make filtered sheets shrink to content, add thumb-friendly mobile option padding, and remove the sheet's top border.

--- a/changelog.d/mobile-sheet-bottom-align.md
+++ b/changelog.d/mobile-sheet-bottom-align.md
@@ -1,0 +1,1 @@
+- Align mobile sheet options to the bottom of the options area and remove the sheet's top border.

--- a/changelog.d/mobile-sheet-bottom-align.md
+++ b/changelog.d/mobile-sheet-bottom-align.md
@@ -1,1 +1,1 @@
-- Align mobile sheet options to the bottom of the options area, make filtered sheets shrink to content, add thumb-friendly mobile option padding, and remove the sheet's top border.
+- Align mobile sheet options to the bottom of the options area, make filtered sheets shrink to content, add thumb-friendly mobile option padding, expose stable test IDs for select internals, and remove the sheet's top border.

--- a/spec/system/haya-select-pagination-spec.js
+++ b/spec/system/haya-select-pagination-spec.js
@@ -78,7 +78,7 @@ describe("HayaSelect pagination", () => {
         await openPaginatedSelect(systemTest)
         await waitForPaginationLabel(systemTest, "Page 1 of 5")
 
-        await clickPaginationSelector(systemTest, "[data-class='pagination-next']")
+        await clickPaginationSelector(systemTest, "[data-testid='haya-select-pagination-next']")
         await waitForPaginationLabel(systemTest, "Page 2 of 5")
         await waitFor({timeout: 5000}, async () => {
           const texts = await helper.optionTexts()
@@ -88,7 +88,7 @@ describe("HayaSelect pagination", () => {
           }
         })
 
-        await clickPaginationSelector(systemTest, "[data-class='pagination-prev']")
+        await clickPaginationSelector(systemTest, "[data-testid='haya-select-pagination-prev']")
         await waitForPaginationLabel(systemTest, "Page 1 of 5")
         await waitFor({timeout: 5000}, async () => {
           const texts = await helper.optionTexts()

--- a/spec/system/haya-select-render-spec.js
+++ b/spec/system/haya-select-render-spec.js
@@ -290,6 +290,32 @@ describe("HayaSelect", () => {
             }
           })
 
+          await waitFor({timeout: 5000}, async () => {
+            const layout = await driver.executeScript(`
+              const container = document.querySelector(${JSON.stringify(optionsContainerSelector)})
+              const option = container && container.querySelector("[data-class='select-option']")
+              const scrollView = container && container.querySelector("[data-class='mobile-options-scroll-view']")
+              if (!container || !option || !scrollView) throw new Error("Missing mobile sheet layout elements")
+
+              const containerStyle = window.getComputedStyle(container)
+              const optionRect = option.getBoundingClientRect()
+              const scrollViewRect = scrollView.getBoundingClientRect()
+
+              return {
+                borderTopWidth: containerStyle.borderTopWidth,
+                distanceToScrollBottom: Math.round(scrollViewRect.bottom - optionRect.bottom)
+              }
+            `)
+
+            if (layout.borderTopWidth !== "0px") {
+              throw new Error(`Expected no top border on mobile sheet, got: ${layout.borderTopWidth}`)
+            }
+
+            if (Math.abs(layout.distanceToScrollBottom) > 4) {
+              throw new Error(`Expected filtered option to align to scroll bottom, got gap: ${layout.distanceToScrollBottom}`)
+            }
+          })
+
           await helper.selectOption({value: "mobile-sheet-40"})
 
           await waitFor({timeout: 5000}, async () => {

--- a/spec/system/haya-select-render-spec.js
+++ b/spec/system/haya-select-render-spec.js
@@ -238,12 +238,20 @@ describe("HayaSelect", () => {
           await waitFor({timeout: 5000}, async () => {
             const metrics = await driver.executeScript(`
               const container = document.querySelector(${JSON.stringify(optionsContainerSelector)})
+              const option = container && container.querySelector("[data-class='select-option']")
               if (!container) throw new Error("Missing mobile options container")
+              if (!option) throw new Error("Missing mobile option")
 
               const rect = container.getBoundingClientRect()
+              const optionStyle = window.getComputedStyle(option)
+
               return {
                 bottom: Math.round(window.innerHeight - rect.bottom),
                 height: rect.height,
+                optionPaddingBottom: parseFloat(optionStyle.paddingBottom),
+                optionPaddingLeft: parseFloat(optionStyle.paddingLeft),
+                optionPaddingRight: parseFloat(optionStyle.paddingRight),
+                optionPaddingTop: parseFloat(optionStyle.paddingTop),
                 windowHeight: window.innerHeight
               }
             `)
@@ -255,6 +263,14 @@ describe("HayaSelect", () => {
 
             if (Math.abs(metrics.bottom) > 2) {
               throw new Error(`Expected sheet to be anchored to bottom, got bottom offset: ${metrics.bottom}`)
+            }
+
+            if (metrics.optionPaddingBottom < 14 || metrics.optionPaddingTop < 14) {
+              throw new Error(`Expected mobile option vertical padding, got top=${metrics.optionPaddingTop} bottom=${metrics.optionPaddingBottom}`)
+            }
+
+            if (metrics.optionPaddingLeft < 16 || metrics.optionPaddingRight < 16) {
+              throw new Error(`Expected mobile option horizontal padding, got left=${metrics.optionPaddingLeft} right=${metrics.optionPaddingRight}`)
             }
           })
 

--- a/spec/system/haya-select-render-spec.js
+++ b/spec/system/haya-select-render-spec.js
@@ -247,10 +247,10 @@ describe("HayaSelect", () => {
                 windowHeight: window.innerHeight
               }
             `)
-            const expectedHeight = metrics.windowHeight * 0.8
+            const maxHeight = metrics.windowHeight * 0.8
 
-            if (Math.abs(metrics.height - expectedHeight) > 8) {
-              throw new Error(`Expected sheet height near 80vh, got: ${metrics.height} of ${metrics.windowHeight}`)
+            if (metrics.height > maxHeight + 8) {
+              throw new Error(`Expected sheet height at most 80vh, got: ${metrics.height} of ${metrics.windowHeight}`)
             }
 
             if (Math.abs(metrics.bottom) > 2) {
@@ -303,9 +303,16 @@ describe("HayaSelect", () => {
 
               return {
                 borderTopWidth: containerStyle.borderTopWidth,
-                distanceToScrollBottom: Math.round(scrollViewRect.bottom - optionRect.bottom)
+                containerHeight: container.getBoundingClientRect().height,
+                distanceToScrollBottom: Math.round(scrollViewRect.bottom - optionRect.bottom),
+                windowHeight: window.innerHeight
               }
             `)
+            const maxHeight = layout.windowHeight * 0.8
+
+            if (layout.containerHeight >= maxHeight - 8) {
+              throw new Error(`Expected filtered sheet to shrink below max height, got: ${layout.containerHeight}`)
+            }
 
             if (layout.borderTopWidth !== "0px") {
               throw new Error(`Expected no top border on mobile sheet, got: ${layout.borderTopWidth}`)

--- a/spec/system/haya-select-render-spec.js
+++ b/spec/system/haya-select-render-spec.js
@@ -85,7 +85,7 @@ describe("HayaSelect", () => {
 
       await waitFor({timeout: 5000}, async () => {
         const chips = await systemTest.all(
-          "[data-testid='hayaSelectStaleValuesRoot'] [data-class='current-option']",
+          "[data-testid='hayaSelectStaleValuesRoot'] [data-testid='haya-select-current-option']",
           {timeout: 0, useBaseSelector: false}
         )
 
@@ -108,7 +108,7 @@ describe("HayaSelect", () => {
 
       await waitFor({timeout: 5000}, async () => {
         const inputs = await systemTest.all(
-          "[data-testid='hayaSelectControlledValuesRoot'] [data-class='current-selected'] input[type='hidden']",
+          "[data-testid='hayaSelectControlledValuesRoot'] [data-testid='haya-select-current-selected'] input[type='hidden']",
           {timeout: 0, visible: null}
         )
         const values = await Promise.all(inputs.map((input) => input.getAttribute("value")))
@@ -134,7 +134,7 @@ describe("HayaSelect", () => {
         await helper.open()
 
         await systemTest.find(
-          "[data-testid='hayaSelectRoot'] [data-component='haya-select'][data-applied-request-id='1']",
+          "[data-testid='hayaSelectRoot'] [data-testid='haya-select'][data-applied-request-id='1']",
           {timeout: 5000}
         )
 
@@ -176,7 +176,7 @@ describe("HayaSelect", () => {
         await helper.open()
 
         await systemTest.find(
-          "[data-testid='hayaSelectRoot'] [data-component='haya-select'][data-applied-request-id='1']",
+          "[data-testid='hayaSelectRoot'] [data-testid='haya-select'][data-applied-request-id='1']",
           {timeout: 5000}
         )
 
@@ -192,7 +192,7 @@ describe("HayaSelect", () => {
 
         await waitFor({timeout: 5000}, async () => {
           const noOptionsContainer = await systemTest.find(
-            `${optionsContainerSelector} [data-class='no-options-container']`,
+            `${optionsContainerSelector} [data-testid='haya-select-no-options-container']`,
             {timeout: 0, useBaseSelector: false}
           )
           const paddingBottom = parseFloat(await noOptionsContainer.getCssValue("padding-bottom"))
@@ -231,14 +231,14 @@ describe("HayaSelect", () => {
           const optionsContainerSelector = await helper.optionsContainerSelector()
 
           await systemTest.find(
-            "[data-testid='hayaSelectMobileSheetRoot'] [data-component='haya-select'][data-options-placement='sheet']",
+            "[data-testid='hayaSelectMobileSheetRoot'] [data-testid='haya-select'][data-options-placement='sheet']",
             {timeout: 5000}
           )
 
           await waitFor({timeout: 5000}, async () => {
             const metrics = await driver.executeScript(`
               const container = document.querySelector(${JSON.stringify(optionsContainerSelector)})
-              const option = container && container.querySelector("[data-class='select-option']")
+              const option = container && container.querySelector("[data-testid='haya-select-option']")
               if (!container) throw new Error("Missing mobile options container")
               if (!option) throw new Error("Missing mobile option")
 
@@ -284,14 +284,14 @@ describe("HayaSelect", () => {
           })
 
           await driver.executeScript(`
-            const scrollView = document.querySelector("[data-class='mobile-options-scroll-view']")
+            const scrollView = document.querySelector("[data-testid='haya-select-mobile-options-scroll-view']")
             if (!scrollView) throw new Error("Missing mobile options scroll view")
             scrollView.scrollTop = scrollView.scrollHeight
             scrollView.dispatchEvent(new Event("scroll", {bubbles: true}))
           `)
 
           await systemTest.interact(
-            {selector: `${optionsContainerSelector} [data-class='search-text-input']`, useBaseSelector: false},
+            {selector: `${optionsContainerSelector} [data-testid='haya-select-search-input']`, useBaseSelector: false},
             "sendKeys",
             Key.chord(Key.CONTROL, "a"),
             Key.BACK_SPACE,
@@ -309,8 +309,8 @@ describe("HayaSelect", () => {
           await waitFor({timeout: 5000}, async () => {
             const layout = await driver.executeScript(`
               const container = document.querySelector(${JSON.stringify(optionsContainerSelector)})
-              const option = container && container.querySelector("[data-class='select-option']")
-              const scrollView = container && container.querySelector("[data-class='mobile-options-scroll-view']")
+              const option = container && container.querySelector("[data-testid='haya-select-option']")
+              const scrollView = container && container.querySelector("[data-testid='haya-select-mobile-options-scroll-view']")
               if (!container || !option || !scrollView) throw new Error("Missing mobile sheet layout elements")
 
               const containerStyle = window.getComputedStyle(container)
@@ -343,7 +343,7 @@ describe("HayaSelect", () => {
 
           await waitFor({timeout: 5000}, async () => {
             const currentSelected = await systemTest.find(
-              "[data-testid='hayaSelectMobileSheetRoot'] [data-class='current-selected']",
+              "[data-testid='hayaSelectMobileSheetRoot'] [data-testid='haya-select-current-selected']",
               {timeout: 0}
             )
             const text = (await currentSelected.getText()).trim()
@@ -372,14 +372,14 @@ describe("HayaSelect", () => {
           await helper.open()
 
           await systemTest.find(
-            "[data-testid='hayaSelectMobileSheetRoot'] [data-component='haya-select'][data-options-placement='sheet']",
+            "[data-testid='hayaSelectMobileSheetRoot'] [data-testid='haya-select'][data-options-placement='sheet']",
             {timeout: 5000}
           )
 
           await driver.manage().window().setRect({height: 844, width: 1280})
           await waitFor({timeout: 5000}, async () => {
             const state = await driver.executeScript(`
-              const root = document.querySelector("[data-testid='hayaSelectMobileSheetRoot'] [data-component='haya-select']")
+              const root = document.querySelector("[data-testid='hayaSelectMobileSheetRoot'] [data-testid='haya-select']")
               const bodyOverflow = document.body.style.overflow
               const documentOverflow = document.documentElement.style.overflow
 
@@ -419,7 +419,7 @@ describe("HayaSelect", () => {
 
         await waitFor({timeout: 5000}, async () => {
           await systemTest.find(
-            `${optionsContainerSelector} [data-class='select-option'][data-value='one']`,
+            `${optionsContainerSelector} [data-testid='haya-select-option'][data-value='one']`,
             {timeout: 0, useBaseSelector: false}
           )
         })
@@ -437,7 +437,7 @@ describe("HayaSelect", () => {
         `)
 
         const selectedElements = await systemTest.all(
-          "[data-class='select-option'][data-selected='true']",
+          "[data-testid='haya-select-option'][data-selected='true']",
           {timeout: 0, useBaseSelector: false}
         )
         const selected = await Promise.all(selectedElements.map((element) => element.getCssValue("background-color")))
@@ -470,19 +470,19 @@ describe("HayaSelect", () => {
         const componentElement = rootId
           ? null
           : await systemTest.find(
-            "[data-testid='hayaSelectMultipleRoot'] [data-component='haya-select']",
+            "[data-testid='hayaSelectMultipleRoot'] [data-testid='haya-select']",
             {timeout: 5000}
           )
         const componentId = rootId || (componentElement ? await componentElement.getAttribute("data-id") : null)
-        const optionsContainerSelector = componentId ? `[data-class='options-container'][data-id='${componentId}']` : "[data-class='options-container']"
+        const optionsContainerSelector = componentId ? `[data-testid='haya-select-options-container'][data-id='${componentId}']` : "[data-testid='haya-select-options-container']"
         const selectContainer = await systemTest.find(
-          "[data-testid='hayaSelectMultipleRoot'] [data-class='select-container']",
+          "[data-testid='hayaSelectMultipleRoot'] [data-testid='haya-select-select-container']",
           {timeout: 5000}
         )
 
         const currentSelectedText = async () => {
           const elements = await systemTest.all(
-            "[data-testid='hayaSelectMultipleRoot'] [data-class='current-selected']",
+            "[data-testid='hayaSelectMultipleRoot'] [data-testid='haya-select-current-selected']",
             {timeout: 0}
           )
           return elements.length > 0 ? (await elements[0].getText()).trim() : ""
@@ -490,7 +490,7 @@ describe("HayaSelect", () => {
 
         const currentOptionCount = async () => {
           const options = await systemTest.all(
-            "[data-testid='hayaSelectMultipleRoot'] [data-class='current-option']",
+            "[data-testid='hayaSelectMultipleRoot'] [data-testid='haya-select-current-option']",
             {timeout: 0}
           )
           return options.length
@@ -534,12 +534,12 @@ describe("HayaSelect", () => {
         await clickElement(selectContainer)
         await waitForOptionsVisible()
         await clickElement(await systemTest.find(
-          `${optionsContainerSelector} [data-class='select-option'][data-value='one']`,
+          `${optionsContainerSelector} [data-testid='haya-select-option'][data-value='one']`,
           {timeout: 5000, useBaseSelector: false}
         ))
         await waitFor({timeout: 5000}, async () => {
           const option = await systemTest.find(
-            `${optionsContainerSelector} [data-class='select-option'][data-value='one']`,
+            `${optionsContainerSelector} [data-testid='haya-select-option'][data-value='one']`,
             {timeout: 0, useBaseSelector: false}
           )
           const selected = await option.getAttribute("data-selected")
@@ -550,12 +550,12 @@ describe("HayaSelect", () => {
         })
 
         await clickElement(await systemTest.find(
-          `${optionsContainerSelector} [data-class='select-option'][data-value='one']`,
+          `${optionsContainerSelector} [data-testid='haya-select-option'][data-value='one']`,
           {timeout: 5000, useBaseSelector: false}
         ))
         await waitFor({timeout: 5000}, async () => {
           const option = await systemTest.find(
-            `${optionsContainerSelector} [data-class='select-option'][data-value='one']`,
+            `${optionsContainerSelector} [data-testid='haya-select-option'][data-value='one']`,
             {timeout: 0, useBaseSelector: false}
           )
           const selected = await option.getAttribute("data-selected")
@@ -593,13 +593,13 @@ describe("HayaSelect", () => {
         const componentElement = rootId
           ? null
           : await systemTest.find(
-            "[data-testid='hayaSelectRoot'] [data-component='haya-select']",
+            "[data-testid='hayaSelectRoot'] [data-testid='haya-select']",
             {timeout: 5000}
           )
         const componentId = rootId || (componentElement ? await componentElement.getAttribute("data-id") : null)
-        const optionsContainerSelector = componentId ? `[data-class='options-container'][data-id='${componentId}']` : "[data-class='options-container']"
+        const optionsContainerSelector = componentId ? `[data-testid='haya-select-options-container'][data-id='${componentId}']` : "[data-testid='haya-select-options-container']"
         const selectContainer = await systemTest.find(
-          "[data-testid='hayaSelectRoot'] [data-class='select-container']",
+          "[data-testid='hayaSelectRoot'] [data-testid='haya-select-select-container']",
           {timeout: 5000}
         )
         const driver = systemTest.getDriver()
@@ -621,7 +621,7 @@ describe("HayaSelect", () => {
 
         const getBorderRadii = async () => {
           const elements = await systemTest.all(
-            "[data-testid='hayaSelectRoot'] [data-class='select-container']",
+            "[data-testid='hayaSelectRoot'] [data-testid='haya-select-select-container']",
             {timeout: 0}
           )
           if (elements.length === 0) return null
@@ -683,7 +683,7 @@ describe("HayaSelect", () => {
             }
 
             const style = window.getComputedStyle(optionsContainer)
-            const root = document.querySelector(${JSON.stringify(helper.rootSelector)} + " [data-component='haya-select']")
+            const root = document.querySelector(${JSON.stringify(helper.rootSelector)} + " [data-testid='haya-select']")
             const optionsPlacement = root ? root.getAttribute("data-options-placement") : null
 
             return {

--- a/spec/system/haya-select-render-spec.js
+++ b/spec/system/haya-select-render-spec.js
@@ -228,12 +228,59 @@ describe("HayaSelect", () => {
           await systemTest.findByTestID("hayaSelectMobileSheetRoot", {timeout: 5000})
           await helper.open()
 
-          const optionsContainerSelector = await helper.optionsContainerSelector()
+          let optionsContainerSelector = await helper.optionsContainerSelector()
 
           await systemTest.find(
             "[data-testid='hayaSelectMobileSheetRoot'] [data-testid='haya-select'][data-options-placement='sheet']",
             {timeout: 5000}
           )
+
+          const backdrop = await systemTest.find("[data-testid='haya-select-mobile-options-backdrop']", {timeout: 5000, useBaseSelector: false})
+          const backdropCursor = await backdrop.getCssValue("cursor")
+
+          if (backdropCursor == "pointer") {
+            throw new Error("Expected mobile options backdrop not to use pointer cursor")
+          }
+
+          await driver.executeScript(`
+            const backdrop = document.querySelector("[data-testid='haya-select-mobile-options-backdrop']")
+            if (!backdrop) throw new Error("Missing mobile options backdrop")
+
+            const rect = backdrop.getBoundingClientRect()
+            const clientX = Math.round(rect.left + (rect.width / 2))
+            const clientY = Math.round(rect.top + 24)
+            const target = document.elementFromPoint(clientX, clientY)
+
+            if (target !== backdrop) {
+              throw new Error("Expected visible backdrop at click point")
+            }
+
+            for (const eventName of ["pointerdown", "mousedown", "pointerup", "mouseup", "click"]) {
+              const eventClass = eventName.startsWith("pointer") && window.PointerEvent ? PointerEvent : MouseEvent
+              target.dispatchEvent(new eventClass(eventName, {
+                bubbles: true,
+                button: 0,
+                cancelable: true,
+                clientX,
+                clientY,
+                pointerId: 1,
+                pointerType: "mouse"
+              }))
+            }
+          `)
+          await waitFor({timeout: 5000}, async () => {
+            const openedElements = await systemTest.all(
+              "[data-testid='hayaSelectMobileSheetRoot'] [data-testid='haya-select'][data-opened='true']",
+              {timeout: 0}
+            )
+
+            if (openedElements.length > 0) {
+              throw new Error("Expected mobile backdrop to close the sheet")
+            }
+          })
+
+          await helper.open()
+          optionsContainerSelector = await helper.optionsContainerSelector()
 
           await waitFor({timeout: 5000}, async () => {
             const metrics = await driver.executeScript(`

--- a/spec/system/pagination-system-test-helpers.js
+++ b/spec/system/pagination-system-test-helpers.js
@@ -2,7 +2,7 @@ import waitFor from "awaitery/build/wait-for.js"
 
 export const setPaginationInputValue = async (systemTest, value) => {
   await waitFor({timeout: 5000}, async () => {
-    const element = await systemTest.find("[data-class='pagination-input']", {useBaseSelector: false})
+    const element = await systemTest.find("[data-testid='haya-select-pagination-input']", {useBaseSelector: false})
     const driver = systemTest.getDriver()
     await driver.executeScript(
       "arguments[0].focus(); arguments[0].value = arguments[1]; arguments[0].dispatchEvent(new Event('input', {bubbles: true})); arguments[0].dispatchEvent(new Event('change', {bubbles: true})); arguments[0].blur();",
@@ -13,7 +13,7 @@ export const setPaginationInputValue = async (systemTest, value) => {
 }
 
 export const paginationLabelText = async (systemTest) => {
-  const labelElements = await systemTest.all("[data-class='pagination-input']", {timeout: 0, useBaseSelector: false})
+  const labelElements = await systemTest.all("[data-testid='haya-select-pagination-input']", {timeout: 0, useBaseSelector: false})
 
   if (labelElements.length === 0) return null
 
@@ -23,10 +23,10 @@ export const paginationLabelText = async (systemTest) => {
 }
 
 export const openPaginatedSelect = async (systemTest) => {
-  const selectContainer = await systemTest.find("[data-testid='hayaSelectPaginationRoot'] [data-class='select-container']")
+  const selectContainer = await systemTest.find("[data-testid='hayaSelectPaginationRoot'] [data-testid='haya-select-select-container']")
   const driver = systemTest.getDriver()
   const searchInputs = await systemTest.all(
-    "[data-testid='hayaSelectPaginationRoot'] [data-class='search-text-input']",
+    "[data-testid='hayaSelectPaginationRoot'] [data-testid='haya-select-search-input']",
     {timeout: 0, visible: true}
   )
 
@@ -38,7 +38,7 @@ export const openPaginatedSelect = async (systemTest) => {
     await systemTest.click(selectContainer)
     await waitFor({timeout: 5000}, async () => {
       const searchInputsAfterClick = await systemTest.all(
-        "[data-testid='hayaSelectPaginationRoot'] [data-class='search-text-input']",
+        "[data-testid='hayaSelectPaginationRoot'] [data-testid='haya-select-search-input']",
         {timeout: 0, visible: true}
       )
 
@@ -55,7 +55,7 @@ export const openPaginatedSelect = async (systemTest) => {
   await systemTest.click(selectContainer)
   await waitFor({timeout: 5000}, async () => {
     const searchInputsAfterClick = await systemTest.all(
-      "[data-testid='hayaSelectPaginationRoot'] [data-class='search-text-input']",
+      "[data-testid='hayaSelectPaginationRoot'] [data-testid='haya-select-search-input']",
       {timeout: 0, visible: true}
     )
 
@@ -65,7 +65,7 @@ export const openPaginatedSelect = async (systemTest) => {
   })
 
   await waitFor({timeout: 5000}, async () => {
-    const paginationElements = await systemTest.all("[data-class='options-pagination']", {timeout: 0, useBaseSelector: false})
+    const paginationElements = await systemTest.all("[data-testid='haya-select-options-pagination']", {timeout: 0, useBaseSelector: false})
 
     if (paginationElements.length === 0) {
       throw new Error("Pagination not visible yet")
@@ -77,12 +77,12 @@ export const openPaginatedSelect = async (systemTest) => {
 
 export const closePaginatedSelect = async (systemTest) => {
   const inputs = await systemTest.all(
-    "[data-testid='hayaSelectPaginationRoot'] [data-class='search-text-input']",
+    "[data-testid='hayaSelectPaginationRoot'] [data-testid='haya-select-search-input']",
     {timeout: 0, visible: true}
   )
 
   if (inputs.length > 0) {
-    const selectContainer = await systemTest.find("[data-testid='hayaSelectPaginationRoot'] [data-class='select-container']")
+    const selectContainer = await systemTest.find("[data-testid='hayaSelectPaginationRoot'] [data-testid='haya-select-select-container']")
     const driver = systemTest.getDriver()
     await driver.executeScript(
       "arguments[0].scrollIntoView({block: 'center', inline: 'center'})",
@@ -114,7 +114,7 @@ export const findPaginationPageButton = async (systemTest, pageNumber) => {
   let matchingButton
 
   await waitFor({timeout: 5000}, async () => {
-    const pageButtons = await systemTest.all("[data-class='pagination-page']", {useBaseSelector: false})
+    const pageButtons = await systemTest.all("[data-testid='haya-select-pagination-page']", {useBaseSelector: false})
 
     for (const pageButton of pageButtons) {
       const buttonText = (await pageButton.getText()).trim()

--- a/src/select/index.jsx
+++ b/src/select/index.jsx
@@ -1,7 +1,7 @@
 import {anythingDifferent} from "set-state-compare/build/diff-utils"
 import Config from "../config.js"
 import {dig, digg} from "diggerize"
-import {Dimensions, Platform, Pressable, ScrollView, TextInput, View} from "react-native"
+import {Dimensions, PanResponder, Platform, Pressable, ScrollView, TextInput, View} from "react-native"
 import React, {createRef, memo, useEffect} from "react"
 import {shapeComponent, ShapeComponent} from "set-state-compare/build/shape-component.js"
 import debounce from "debounce"
@@ -1328,15 +1328,22 @@ class HayaSelect extends ShapeComponent {
   }
 
   /**
-   * @param {import("react").SyntheticEvent} event Press event.
+   * @param {import("react").SyntheticEvent} event Responder event.
    * @returns {void}
    */
-  onMobileOptionsBackdropPress = (event) => {
-    event.preventDefault()
-    event.stopPropagation()
+  onMobileOptionsBackdropRelease = (event) => {
+    event.preventDefault?.()
+    event.stopPropagation?.()
 
     this.closeOptions()
   }
+
+  mobileOptionsBackdropPanResponder = PanResponder.create({
+    onStartShouldSetPanResponder: () => true,
+    onMoveShouldSetPanResponder: () => false,
+    onPanResponderRelease: this.tt.onMobileOptionsBackdropRelease,
+    onPanResponderTerminate: this.tt.onMobileOptionsBackdropRelease
+  })
 
   /** @returns {number|null} */
   paginationTotalPages() {
@@ -1718,9 +1725,8 @@ class HayaSelect extends ShapeComponent {
         })}
         testID="haya-select-mobile-options-overlay"
       >
-        <Pressable
+        <View
           dataSet={this.mobileOptionsBackdropDataSet ||= {class: "mobile-options-backdrop"}}
-          onPress={this.tt.onMobileOptionsBackdropPress}
           style={this.stylingFor("mobileOptionsBackdrop", styles.mobileOptionsBackdrop ||= {
             position: "absolute",
             top: 0,
@@ -1730,6 +1736,7 @@ class HayaSelect extends ShapeComponent {
             backgroundColor: "rgba(15, 23, 42, 0.32)"
           })}
           testID="haya-select-mobile-options-backdrop"
+          {...this.tt.mobileOptionsBackdropPanResponder.panHandlers}
         />
         <View
           dataSet={this.cache(

--- a/src/select/index.jsx
+++ b/src/select/index.jsx
@@ -1684,10 +1684,8 @@ class HayaSelect extends ShapeComponent {
       height: sheetHeight,
       maxHeight: sheetHeight,
       backgroundColor: "#fff",
-      borderTopColor: "#cbd5e1",
       borderTopLeftRadius: 18,
       borderTopRightRadius: 18,
-      borderTopWidth: 1,
       overflow: "hidden",
       visibility: this.s.optionsVisibility
     }, [sheetHeight, this.s.optionsVisibility])
@@ -1731,6 +1729,10 @@ class HayaSelect extends ShapeComponent {
           testID="haya-select-mobile-options-container"
         >
           <ScrollView
+            contentContainerStyle={this.stylingFor("mobileOptionsScrollContent", styles.mobileOptionsScrollContent ||= {
+              flexGrow: 1,
+              justifyContent: "flex-end"
+            })}
             dataSet={this.mobileOptionsScrollViewDataSet ||= {class: "mobile-options-scroll-view"}}
             keyboardShouldPersistTaps="handled"
             nestedScrollEnabled

--- a/src/select/index.jsx
+++ b/src/select/index.jsx
@@ -879,6 +879,7 @@ class HayaSelect extends ShapeComponent {
         key={key}
         option={loadedOption}
         onOptionClicked={this.tt.onOptionClicked}
+        optionsPlacement={this.s.optionsPlacement}
         presentOption={this.tt.presentOption}
         selectedBackgroundColor={this.props.selectedBackgroundColor}
         selectedHoverBackgroundColor={this.props.selectedHoverBackgroundColor}

--- a/src/select/index.jsx
+++ b/src/select/index.jsx
@@ -632,6 +632,7 @@ class HayaSelect extends ShapeComponent {
           toggles: Boolean(toggleOptions)
         }, [this.s.loadOptionsAppliedRequestId, className, id, opened, optionsPlacement, this.s.loadOptionsRequestId, Boolean(toggleOptions)])}
         style={this.stylingFor("main")}
+        testID="haya-select"
       >
         <Pressable
           dataSet={this.selectContainerDataSet ||= {class: "select-container"}}
@@ -639,10 +640,12 @@ class HayaSelect extends ShapeComponent {
           onPress={this.tt.onSelectClicked}
           ref={this.tt.selectContainerRef}
           style={selectContainerStyleActual}
+          testID="haya-select-select-container"
         >
           <View
             dataSet={this.currentSelectedDataSet ||= {class: "current-selected"}}
             style={this.stylingFor("currentSelected", this.currentSelectedStyle ||= {flex: 1, flexWrap: "wrap", overflow: "hidden"})}
+            testID="haya-select-current-selected"
           >
             {opened && !mobileOptionsSheet &&
               this.searchTextInput()
@@ -682,6 +685,7 @@ class HayaSelect extends ShapeComponent {
                     dataSet={this.currentOptionDataSet ||= {class: "current-option"}}
                     key={currentOption.key || `current-value-${currentOption.value}`}
                     style={this.stylingFor("currentOption", {marginRight: 6})}
+                    testID="haya-select-current-option"
                   >
                     {currentOption.type == "group" &&
                       <View style={this.stylingFor("currentOptionGroup", this.currentOptionGroupStyle ||= {fontWeight: "bold"})}>
@@ -717,6 +721,7 @@ class HayaSelect extends ShapeComponent {
               marginLeft: "auto",
               marginRight: 8
             })}
+            testID="haya-select-chevron-container"
           >
             <FontAwesomeIcon name={opened ? "chevron-up" : "chevron-down"} style={this.stylingFor("chevron", this.chevronStyle ||= {fontSize: 12})} />
           </View>
@@ -725,6 +730,7 @@ class HayaSelect extends ShapeComponent {
           dataSet={this.endOfSelectDataSet ||= {class: "end-of-select"}}
           onLayout={this.tt.onEndOfSelectLayout}
           ref={endOfSelectRef}
+          testID="haya-select-end-of-select"
         />
         {opened && this.p.optionsPortal &&
           <Portal name={this.portalName()}>
@@ -1537,10 +1543,12 @@ class HayaSelect extends ShapeComponent {
           borderTopWidth: 1,
           padding: 8
         }}
+        testID="haya-select-options-pagination"
       >
         <View
           dataSet={dataSets.paginationHeader ||= {class: "pagination-header"}}
           style={styles.paginationHeader ||= {flexDirection: "row", alignItems: "center", justifyContent: "space-between"}}
+          testID="haya-select-pagination-header"
         >
           <Pressable
             dataSet={dataSets.paginationPrevButton ||= {class: "pagination-prev"}}
@@ -1557,6 +1565,7 @@ class HayaSelect extends ShapeComponent {
               opacity: prevDisabled ? 0.4 : 1,
               width: 30
             }}
+            testID="haya-select-pagination-prev"
           >
             <FontAwesomeIcon
               name="chevron-left"
@@ -1579,6 +1588,7 @@ class HayaSelect extends ShapeComponent {
               paddingHorizontal: 10,
               paddingVertical: 6
             }}
+            testID="haya-select-pagination-label"
           >
             <TextInput
               dataSet={dataSets.paginationInput ||= {class: "pagination-input"}}
@@ -1600,6 +1610,7 @@ class HayaSelect extends ShapeComponent {
                 textAlign: "center",
                 width: 120
               }}
+              testID="haya-select-pagination-input"
               value={this.paginationInputValue(totalPages)}
             />
           </View>
@@ -1618,6 +1629,7 @@ class HayaSelect extends ShapeComponent {
               opacity: nextDisabled ? 0.4 : 1,
               width: 30
             }}
+            testID="haya-select-pagination-next"
           >
             <FontAwesomeIcon
               name="chevron-right"
@@ -1633,6 +1645,7 @@ class HayaSelect extends ShapeComponent {
             justifyContent: "center",
             marginTop: 8
           }}
+          testID="haya-select-pagination-pages"
         >
           {this.paginationPageItems(totalPages).map((item) => {
             if (item.type == "ellipsis") {
@@ -1641,6 +1654,7 @@ class HayaSelect extends ShapeComponent {
                   dataSet={dataSets[`paginationEllipsis-${item.key}`] ||= {class: "pagination-ellipsis"}}
                   key={item.key}
                   style={styles.paginationEllipsis ||= {paddingHorizontal: 6}}
+                  testID="haya-select-pagination-ellipsis"
                 >
                   <Text
                     style={styles.paginationEllipsisText ||= {
@@ -1726,7 +1740,7 @@ class HayaSelect extends ShapeComponent {
           onLayout={this.tt.onOptionsContainerLayout}
           ref={this.tt.optionsContainerRef}
           style={sheetStyle}
-          testID="haya-select-mobile-options-container"
+          testID="haya-select-options-container"
         >
           <ScrollView
             contentContainerStyle={this.stylingFor("mobileOptionsScrollContent", styles.mobileOptionsScrollContent ||= {
@@ -1783,6 +1797,7 @@ class HayaSelect extends ShapeComponent {
               paddingRight: 8,
               paddingTop: 10
             })}
+            testID="haya-select-no-options-container"
           >
             <Text>
               {this.p.noOptionsText ? this.p.noOptionsText() : this.translate(".no_options_found")}
@@ -1879,6 +1894,7 @@ class HayaSelect extends ShapeComponent {
         onLayout={this.tt.onOptionsContainerLayout}
         ref={this.tt.optionsContainerRef}
         style={style}
+        testID="haya-select-options-container"
       >
         {Platform.OS == "web" &&
           optionsContent

--- a/src/select/index.jsx
+++ b/src/select/index.jsx
@@ -1673,7 +1673,7 @@ class HayaSelect extends ShapeComponent {
    * @returns {import("react").ReactNode}
    */
   mobileOptionsContainer({id, optionsContent}) {
-    const sheetHeight = Math.max(Math.round(Dimensions.get("window").height * 0.8), 240)
+    const sheetMaxHeight = Math.round(Dimensions.get("window").height * 0.8)
     const sheetStyle = this.stylingFor("optionsContainer", {
       position: "absolute",
       zIndex: 100000,
@@ -1681,14 +1681,13 @@ class HayaSelect extends ShapeComponent {
       left: 0,
       right: 0,
       bottom: 0,
-      height: sheetHeight,
-      maxHeight: sheetHeight,
+      maxHeight: sheetMaxHeight,
       backgroundColor: "#fff",
       borderTopLeftRadius: 18,
       borderTopRightRadius: 18,
       overflow: "hidden",
       visibility: this.s.optionsVisibility
-    }, [sheetHeight, this.s.optionsVisibility])
+    }, [sheetMaxHeight, this.s.optionsVisibility])
 
     return (
       <View
@@ -1736,7 +1735,7 @@ class HayaSelect extends ShapeComponent {
             dataSet={this.mobileOptionsScrollViewDataSet ||= {class: "mobile-options-scroll-view"}}
             keyboardShouldPersistTaps="handled"
             nestedScrollEnabled
-            style={this.stylingFor("mobileOptionsScrollView", styles.mobileOptionsScrollView ||= {flex: 1})}
+            style={this.stylingFor("mobileOptionsScrollView", styles.mobileOptionsScrollView ||= {flexShrink: 1})}
             testID="haya-select-mobile-options-scroll-view"
           >
             {optionsContent}

--- a/src/select/option-group.jsx
+++ b/src/select/option-group.jsx
@@ -21,6 +21,7 @@ export default memo(shapeComponent(class OptionGroup extends ShapeComponent {
           color: "#000",
           fontWeight: "bold"
         }}
+        testID="haya-select-option-group"
       >
         <Text>
           {this.props.option.text}

--- a/src/select/option.jsx
+++ b/src/select/option.jsx
@@ -94,6 +94,7 @@ class Option extends ShapeComponent {
         onPointerOver={this.tt.onPointerOver}
         onPointerOut={this.tt.onPointerOut}
         style={style}
+        testID="haya-select-option"
       >
         {this.p.presentOption(option, "option")}
       </PressableComponent>

--- a/src/select/option.jsx
+++ b/src/select/option.jsx
@@ -14,6 +14,7 @@ const PressableComponent = /** @type {any} */ (Pressable)
  * @property {string} [icon]
  * @property {(event: import("react").SyntheticEvent, option: Record<string, any>) => void} onOptionClicked
  * @property {Record<string, any>} option
+ * @property {"above"|"below"|"sheet"|undefined} [optionsPlacement]
  * @property {(option: Record<string, any>, mode: string) => import("react").ReactNode} presentOption
  * @property {string} [selectedBackgroundColor]
  * @property {string} [selectedHoverBackgroundColor]
@@ -33,6 +34,7 @@ class Option extends ShapeComponent {
     icon: PropTypes.string,
     onOptionClicked: PropTypes.func.isRequired,
     option: PropTypes.object.isRequired,
+    optionsPlacement: PropTypes.oneOf(["above", "below", "sheet"]),
     presentOption: PropTypes.func.isRequired,
     selectedBackgroundColor: PropTypes.string,
     selectedHoverBackgroundColor: PropTypes.string
@@ -47,16 +49,18 @@ class Option extends ShapeComponent {
     const {currentOptionValues, option} = this.p
     const {hover} = this.s
     const disabled = Boolean(option.disabled)
+    const mobileSheet = this.p.optionsPlacement == "sheet"
     const selected = Boolean(currentOptionValues?.find((currentOptionValue) => currentOptionValue == option.value))
 
     const style = useMemo(() => {
       const selectedBackgroundColor = this.props.selectedBackgroundColor || "#cfe1ff"
       const selectedHoverBackgroundColor = this.props.selectedHoverBackgroundColor || "#9bbcfb"
       const style = {
-        paddingTop: 4,
-        paddingRight: 8,
-        paddingBottom: 4,
-        paddingLeft: 8,
+        paddingTop: mobileSheet ? 14 : 4,
+        paddingRight: mobileSheet ? 16 : 8,
+        paddingBottom: mobileSheet ? 14 : 4,
+        paddingLeft: mobileSheet ? 16 : 8,
+        minHeight: mobileSheet ? 48 : undefined,
         color: "#000"
       }
 
@@ -76,7 +80,7 @@ class Option extends ShapeComponent {
       }
 
       return style
-    }, [disabled, hover, selected, this.props.selectedBackgroundColor, this.props.selectedHoverBackgroundColor])
+    }, [disabled, hover, mobileSheet, selected, this.props.selectedBackgroundColor, this.props.selectedHoverBackgroundColor])
 
     return (
       <PressableComponent

--- a/src/select/pagination-page-button.jsx
+++ b/src/select/pagination-page-button.jsx
@@ -48,6 +48,7 @@ export default memo(shapeComponent(class PaginationPageButton extends ShapeCompo
           marginHorizontal: 4,
           width: 28
         }}
+        testID="haya-select-pagination-page"
       >
         <Text
           style={styles[`paginationPageText-${active}`] ||= {

--- a/src/system-test-helpers.js
+++ b/src/system-test-helpers.js
@@ -23,11 +23,11 @@ export default class HayaSelectSystemTestHelper {
     this.systemTest = systemTest
     this.testId = testId
     this.rootSelector = `[data-testid='${testId}']`
-    this.componentSelector = `${this.rootSelector} [data-component='haya-select']`
-    this.chevronContainerSelector = `${this.rootSelector} [data-class='chevron-container']`
-    this.selectContainerSelector = `${this.rootSelector} [data-class='select-container']`
-    this.searchInputSelector = `${this.rootSelector} [data-class='search-text-input']`
-    this.optionsContainerSelectorFallback = "[data-class='options-container']"
+    this.componentSelector = `${this.rootSelector} [data-testid='haya-select']`
+    this.chevronContainerSelector = `${this.rootSelector} [data-testid='haya-select-chevron-container']`
+    this.selectContainerSelector = `${this.rootSelector} [data-testid='haya-select-select-container']`
+    this.searchInputSelector = `${this.rootSelector} [data-testid='haya-select-search-input']`
+    this.optionsContainerSelectorFallback = "[data-testid='haya-select-options-container']"
   }
 
   /** @returns {Promise<void>} */
@@ -114,7 +114,7 @@ export default class HayaSelectSystemTestHelper {
 
     const id = rootId || (elements.length > 0 ? await elements[0].getAttribute("data-id") : null)
 
-    this._optionsContainerSelector = id ? `[data-class='options-container'][data-id='${id}']` : this.optionsContainerSelectorFallback
+    this._optionsContainerSelector = id ? `[data-testid='haya-select-options-container'][data-id='${id}']` : this.optionsContainerSelectorFallback
 
     return this._optionsContainerSelector
   }
@@ -122,7 +122,7 @@ export default class HayaSelectSystemTestHelper {
   /** @returns {Promise<string[]>} */
   async optionTexts() {
     const optionsContainerSelector = await this.optionsContainerSelector()
-    const options = await this.findElements(`${optionsContainerSelector} [data-class='select-option']`)
+    const options = await this.findElements(`${optionsContainerSelector} [data-testid='haya-select-option']`)
 
     return await Promise.all(options.map(async (option) => (await option.getText()).trim()))
   }
@@ -145,7 +145,7 @@ export default class HayaSelectSystemTestHelper {
     if (typeof value != "undefined") {
       await waitFor({timeout: 5000}, async () => {
         const optionsContainerSelector = await this.optionsContainerSelector()
-        const options = await this.findElements(`${optionsContainerSelector} [data-class='select-option'][data-value='${value}']`)
+        const options = await this.findElements(`${optionsContainerSelector} [data-testid='haya-select-option'][data-value='${value}']`)
         const option = options[0]
 
         if (!option) {
@@ -160,7 +160,7 @@ export default class HayaSelectSystemTestHelper {
     if (typeof index == "number") {
       await waitFor({timeout: 5000}, async () => {
         const optionsContainerSelector = await this.optionsContainerSelector()
-        const options = await this.findElements(`${optionsContainerSelector} [data-class='select-option']`)
+        const options = await this.findElements(`${optionsContainerSelector} [data-testid='haya-select-option']`)
         const option = options[index]
 
         if (!option) throw new Error(`No option at index: ${index}`)
@@ -173,7 +173,7 @@ export default class HayaSelectSystemTestHelper {
     if (text) {
       await waitFor({timeout: 5000}, async () => {
         const optionsContainerSelector = await this.optionsContainerSelector()
-        const options = await this.findElements(`${optionsContainerSelector} [data-class='select-option']`)
+        const options = await this.findElements(`${optionsContainerSelector} [data-testid='haya-select-option']`)
 
         for (const option of options) {
           const optionText = (await option.getText()).trim()


### PR DESCRIPTION
## Summary
- Align short mobile sheet option lists to the bottom of the scroll area so options sit closer to thumb reach
- Remove the mobile sheet container's top border
- Add mobile sheet system coverage for the bottom alignment and missing top border

## Checks
- npm run lint
- npm run typecheck
- npm run test:dist -- spec/system/haya-select-render-spec.js:211