### PR TITLE
Fix mobile sheet options container height

### DIFF
--- a/changelog.d/mobile-sheet-options-container-height.md
+++ b/changelog.d/mobile-sheet-options-container-height.md
@@ -1,0 +1,1 @@
+- Remove the options container `data-class` marker and prevent mobile sheet mode from keeping fixed custom heights.

--- a/example/screens/mobile-sheet-select-screen.tsx
+++ b/example/screens/mobile-sheet-select-screen.tsx
@@ -8,6 +8,14 @@ const mobileSheetOptions = Array.from({length: 40}).map((_, index) => ({
   text: `Mobile Sheet Option ${index + 1}`
 }))
 
+const mobileSheetStyles = {
+  optionsContainer: ({optionsPlacement}: {optionsPlacement?: string}) => {
+    if (optionsPlacement != "sheet") return undefined
+
+    return {height: 999}
+  }
+}
+
 export default function MobileSheetSelectScreen() {
   return (
     <TestScrollView>
@@ -17,6 +25,7 @@ export default function MobileSheetSelectScreen() {
             options={mobileSheetOptions}
             placeholder="Pick mobile sheet"
             search
+            styles={mobileSheetStyles}
           />
         </View>
       </Group>

--- a/spec/system/haya-select-render-spec.js
+++ b/spec/system/haya-select-render-spec.js
@@ -294,7 +294,9 @@ describe("HayaSelect", () => {
 
               return {
                 bottom: Math.round(window.innerHeight - rect.bottom),
+                dataClass: container.getAttribute("data-class"),
                 height: rect.height,
+                inlineHeight: container.style.height,
                 optionPaddingBottom: parseFloat(optionStyle.paddingBottom),
                 optionPaddingLeft: parseFloat(optionStyle.paddingLeft),
                 optionPaddingRight: parseFloat(optionStyle.paddingRight),
@@ -306,6 +308,14 @@ describe("HayaSelect", () => {
 
             if (metrics.height > maxHeight + 8) {
               throw new Error(`Expected sheet height at most 80vh, got: ${metrics.height} of ${metrics.windowHeight}`)
+            }
+
+            if (metrics.dataClass) {
+              throw new Error(`Expected options container to use testID instead of data-class, got: ${metrics.dataClass}`)
+            }
+
+            if (metrics.inlineHeight) {
+              throw new Error(`Expected mobile options container not to keep a fixed height, got: ${metrics.inlineHeight}`)
             }
 
             if (Math.abs(metrics.bottom) > 2) {
@@ -367,7 +377,9 @@ describe("HayaSelect", () => {
               return {
                 borderTopWidth: containerStyle.borderTopWidth,
                 containerHeight: container.getBoundingClientRect().height,
+                dataClass: container.getAttribute("data-class"),
                 distanceToScrollBottom: Math.round(scrollViewRect.bottom - optionRect.bottom),
+                inlineHeight: container.style.height,
                 windowHeight: window.innerHeight
               }
             `)
@@ -375,6 +387,14 @@ describe("HayaSelect", () => {
 
             if (layout.containerHeight >= maxHeight - 8) {
               throw new Error(`Expected filtered sheet to shrink below max height, got: ${layout.containerHeight}`)
+            }
+
+            if (layout.dataClass) {
+              throw new Error(`Expected filtered options container to use testID instead of data-class, got: ${layout.dataClass}`)
+            }
+
+            if (layout.inlineHeight) {
+              throw new Error(`Expected filtered mobile options container not to keep a fixed height, got: ${layout.inlineHeight}`)
             }
 
             if (layout.borderTopWidth !== "0px") {

--- a/src/select/index.jsx
+++ b/src/select/index.jsx
@@ -1696,7 +1696,7 @@ class HayaSelect extends ShapeComponent {
    */
   mobileOptionsContainer({id, optionsContent}) {
     const sheetMaxHeight = Math.round(Dimensions.get("window").height * 0.8)
-    const sheetStyle = this.stylingFor("optionsContainer", {
+    let sheetStyle = this.stylingFor("optionsContainer", {
       position: "absolute",
       zIndex: 100000,
       elevation: 100000,
@@ -1710,6 +1710,11 @@ class HayaSelect extends ShapeComponent {
       overflow: "hidden",
       visibility: this.s.optionsVisibility
     }, [sheetMaxHeight, this.s.optionsVisibility])
+
+    if ("height" in sheetStyle) {
+      sheetStyle = Object.assign({}, sheetStyle)
+      delete sheetStyle.height
+    }
 
     return (
       <View
@@ -1741,7 +1746,7 @@ class HayaSelect extends ShapeComponent {
         <View
           dataSet={this.cache(
             "mobileOptionsContainerDataSet",
-            {class: "options-container", id, role: "dialog", optionsPlacement: "sheet", optionsVisibility: this.s.optionsVisibility || "hidden"},
+            {id, role: "dialog", optionsPlacement: "sheet", optionsVisibility: this.s.optionsVisibility || "hidden"},
             [id, this.s.optionsVisibility]
           )}
           onLayout={this.tt.onOptionsContainerLayout}
@@ -1757,7 +1762,7 @@ class HayaSelect extends ShapeComponent {
             dataSet={this.mobileOptionsScrollViewDataSet ||= {class: "mobile-options-scroll-view"}}
             keyboardShouldPersistTaps="handled"
             nestedScrollEnabled
-            style={this.stylingFor("mobileOptionsScrollView", styles.mobileOptionsScrollView ||= {flexShrink: 1})}
+            style={this.stylingFor("mobileOptionsScrollView", styles.mobileOptionsScrollView ||= {flexGrow: 0, flexShrink: 1, minHeight: 0})}
             testID="haya-select-mobile-options-scroll-view"
           >
             {optionsContent}
@@ -1895,7 +1900,7 @@ class HayaSelect extends ShapeComponent {
       <View
         dataSet={this.cache(
           "optionsContainerDataSet",
-          {class: "options-container", id, role: "dialog", optionsVisibility: optionsVisibility || "hidden"},
+          {id, role: "dialog", optionsVisibility: optionsVisibility || "hidden"},
           [id, optionsVisibility]
         )}
         onLayout={this.tt.onOptionsContainerLayout}


### PR DESCRIPTION
## Summary
- Remove the options container data-class marker so the existing testID/data-id path is the selector contract.
- Strip fixed height overrides in mobile sheet mode while keeping max-height behavior.
- Add regression coverage with a mobile sheet example that attempts to set a fixed height.

## Checks
- npm run test:dist -- spec/system/haya-select-render-spec.js:226
- npm run lint
- npm run typecheck
- git diff --check