### PR TITLE
Scope HayaSelect helper options to opened component

### DIFF
--- a/changelog.d/scope-helper-options.md
+++ b/changelog.d/scope-helper-options.md
@@ -1,0 +1,1 @@
+- Scope HayaSelect system-test helper option lookups to the opened component when duplicate test IDs are present.

--- a/example/screens/duplicate-test-id-select-screen.tsx
+++ b/example/screens/duplicate-test-id-select-screen.tsx
@@ -1,0 +1,31 @@
+import React from "react"
+import {View} from "react-native"
+
+import {Group, HayaSelect, selectOptions, TestScrollView} from "./shared"
+
+export default function DuplicateTestIdSelectScreen() {
+  return (
+    <TestScrollView>
+      <View style={{display: "none"}}>
+        <Group name="Hidden Duplicate Select">
+          <View testID="hayaSelectRoot">
+            <HayaSelect
+              options={selectOptions}
+              placeholder="Pick hidden"
+              search
+            />
+          </View>
+        </Group>
+      </View>
+      <Group name="Visible Duplicate Select">
+        <View testID="hayaSelectRoot">
+          <HayaSelect
+            options={selectOptions}
+            placeholder="Pick visible"
+            search
+          />
+        </View>
+      </Group>
+    </TestScrollView>
+  )
+}

--- a/example/screens/index.tsx
+++ b/example/screens/index.tsx
@@ -3,6 +3,7 @@ import React from "react"
 import BasicSelectScreen from "./basic-select-screen"
 import CloseOnChangeScreen from "./close-on-change-screen"
 import ControlledValuesScreen from "./controlled-values-screen"
+import DuplicateTestIdSelectScreen from "./duplicate-test-id-select-screen"
 import FilterSelectScreen from "./filter-select-screen"
 import MobileSheetResizeScreen from "./mobile-sheet-resize-screen"
 import MobileSheetSelectScreen from "./mobile-sheet-select-screen"
@@ -26,6 +27,7 @@ const screens: Record<string, React.ComponentType> = {
   "basic-select": BasicSelectScreen,
   "close-on-change": CloseOnChangeScreen,
   "controlled-values": ControlledValuesScreen,
+  "duplicate-test-id-select": DuplicateTestIdSelectScreen,
   "filter-select": FilterSelectScreen,
   "mobile-sheet-resize": MobileSheetResizeScreen,
   "mobile-sheet-select": MobileSheetSelectScreen,

--- a/spec/system/haya-select-render-spec.js
+++ b/spec/system/haya-select-render-spec.js
@@ -178,6 +178,17 @@ describe("HayaSelect", () => {
     })
   })
 
+  it("scopes named helper option lookup to the opened select", async () => {
+    await timeout({errorMessage: "render test timed out: scopes named helper option lookup to the opened select", timeout: 30000}, async () => {
+      await runSystemTest(async (systemTest) => {
+        await systemTest.findByTestID("hayaSelectRoot", {timeout: 5000})
+
+        await pickHayaSelectOption(systemTest, "hayaSelectRoot", {optionValue: "two"})
+        await expectHayaSelectCurrentOptions(systemTest, "hayaSelectRoot", ["Two"])
+      }, {screen: "duplicate-test-id-select"})
+    })
+  })
+
   it("clicks visible options in an already-open dropdown", async () => {
     await timeout({errorMessage: "render test timed out: clicks visible options in an already-open dropdown", timeout: 30000}, async () => {
       await runSystemTest(async (systemTest) => {

--- a/src/system-test-helpers.js
+++ b/src/system-test-helpers.js
@@ -190,15 +190,9 @@ export default class HayaSelectSystemTestHelper {
   async optionsContainerSelector() {
     if (this._optionsContainerSelector) return this._optionsContainerSelector
 
-    const rootElements = await this.findElements(this.rootSelector)
-    const rootId = rootElements.length > 0 ? await rootElements[0].getAttribute("data-id") : null
-    let elements = rootElements
-
-    if (!rootId) {
-      elements = await this.findElements(this.componentSelector)
-    }
-
-    const id = rootId || (elements.length > 0 ? await elements[0].getAttribute("data-id") : null)
+    const openedElements = await this.findElements(`${this.componentSelector}[data-opened='true']`)
+    const componentElements = openedElements.length > 0 ? openedElements : await this.findVisibleElements(this.componentSelector)
+    const id = componentElements.length > 0 ? await componentElements[0].getAttribute("data-id") : null
 
     this._optionsContainerSelector = id ? `[data-testid='haya-select/options-container'][data-id="${cssAttributeValue(id)}"]` : this.optionsContainerSelectorFallback
 


### PR DESCRIPTION
## Summary
- resolve system-test helper option containers from the opened HayaSelect component
- add duplicate testID example coverage for the helper path
- add a changelog fragment

## Tests
- npm run lint
- npm run typecheck
- SYSTEM_TEST_HOST=dist npm test -- spec/system/haya-select-render-spec.js