### PR TITLE
Add closeOnChange for multiple selects

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,20 @@ The callback receives the current `searchValue`, `page`, and optional `values` w
 
 If `totalCount` and `page` are provided, the options list shows pagination controls with previous/next buttons, a page range around the current page, and a "Page X of Y" label that can be clicked to enter a page number manually.
 
+## Closing multiple selects after a change
+
+Multiple selects stay open after option clicks by default so users can pick several values quickly. Use `closeOnChange` for filter-style selects that update route params or otherwise re-render immediately after each selection.
+
+```jsx
+<HayaSelect
+  closeOnChange
+  multiple
+  onChangeValue={setSelectedValues}
+  options={options}
+  values={selectedValues}
+/>
+```
+
 ## System test helpers
 
 Browser system-test suites can import helpers from the dedicated test-helper entrypoint:

--- a/changelog.d/close-on-change-multiple.md
+++ b/changelog.d/close-on-change-multiple.md
@@ -1,0 +1,1 @@
+- Add `closeOnChange` so filter-style multiple selects can close after each picked option.

--- a/example/screens/close-on-change-screen.tsx
+++ b/example/screens/close-on-change-screen.tsx
@@ -11,6 +11,7 @@ const actionTypeOptions = [
 
 export default function CloseOnChangeScreen() {
   const [actionTypeValue, setActionTypeValue] = useState<string | null>(null)
+  const [filterValues, setFilterValues] = useState<Array<string>>([])
 
   return (
     <TestScrollView>
@@ -26,6 +27,21 @@ export default function CloseOnChangeScreen() {
               Points selected
             </Text>
           }
+        </View>
+      </Group>
+      <Group name="Close On Change Multiple Select">
+        <View testID="hayaSelectCloseOnChangeMultipleRoot">
+          <HayaSelect
+            closeOnChange
+            multiple
+            onChangeValue={(values) => setFilterValues(Array.isArray(values) ? values.map(String) : [])}
+            options={actionTypeOptions}
+            placeholder="Pick filters"
+            values={filterValues}
+          />
+          <Text testID="hayaSelectCloseOnChangeMultipleValues">
+            {filterValues.join(",")}
+          </Text>
         </View>
       </Group>
     </TestScrollView>

--- a/metro.config.js
+++ b/metro.config.js
@@ -1,0 +1,3 @@
+const {getDefaultConfig} = require("expo/metro-config")
+
+module.exports = getDefaultConfig(__dirname)

--- a/spec/system/haya-select-render-spec.js
+++ b/spec/system/haya-select-render-spec.js
@@ -79,6 +79,32 @@ describe("HayaSelect", () => {
     })
   })
 
+  it("closes controlled multiple options when closeOnChange is enabled", async () => {
+    await timeout({errorMessage: "render test timed out: closes controlled multiple options when closeOnChange is enabled", timeout: 30000}, async () => {
+      await runSystemTest(async (systemTest) => {
+        const helper = new HayaSelectSystemTestHelper({systemTest, testId: "hayaSelectCloseOnChangeMultipleRoot"})
+
+        await systemTest.findByTestID("hayaSelectCloseOnChangeMultipleRoot", {timeout: 5000})
+        await helper.open()
+        await helper.selectOption({value: "email"})
+
+        await waitFor({timeout: 5000}, async () => {
+          if (await helper.isOpen()) {
+            throw new Error("Expected closeOnChange multiple select to close after selecting an option")
+          }
+        })
+        await waitFor({timeout: 5000}, async () => {
+          const values = await systemTest.findByTestID("hayaSelectCloseOnChangeMultipleValues", {timeout: 0})
+          const text = await values.getText()
+
+          if (text.trim() !== "email") {
+            throw new Error(`Expected controlled multiple value to update, got: ${text}`)
+          }
+        })
+      }, {screen: "close-on-change"})
+    })
+  })
+
   it("renders without crashing when values include ids missing from options", async () => {
     await runSystemTest(async (systemTest) => {
       await systemTest.findByTestID("hayaSelectStaleValuesRoot", {timeout: 5000})

--- a/src/select/index.jsx
+++ b/src/select/index.jsx
@@ -54,6 +54,7 @@ const MOBILE_OPTIONS_MAX_WIDTH = 768
  * @typedef {object} HayaSelectProps
  * @property {string} [attribute]
  * @property {string} [className]
+ * @property {boolean} [closeOnChange]
  * @property {object} [defaultToggled]
  * @property {string|number} [defaultValue]
  * @property {Array<string|number>} [defaultValues]
@@ -212,6 +213,7 @@ const nameForComponentWithMultiple = (component) => {
 /** @augments {ShapeComponent<HayaSelectProps, HayaSelectState>} */
 class HayaSelect extends ShapeComponent {
   static defaultProps = {
+    closeOnChange: false,
     debug: false,
     mobileOptionsMode: "auto",
     multiple: false,
@@ -229,6 +231,7 @@ class HayaSelect extends ShapeComponent {
   static propTypes = propTypesExact({
     attribute: PropTypes.string,
     className: PropTypes.string,
+    closeOnChange: PropTypes.bool.isRequired,
     defaultToggled: PropTypes.object,
     defaultValue: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     defaultValues: PropTypes.array,
@@ -380,6 +383,7 @@ class HayaSelect extends ShapeComponent {
     if (this.isDebugEnabled()) this.debugLog("setup", {
       hasControlledValues: "values" in this.props,
       hasControlledToggled: "toggled" in this.props,
+      closeOnChange: this.p.closeOnChange,
       multiple: this.p.multiple,
       optionsType: Array.isArray(this.props.options) ? "array" : typeof this.props.options
     })
@@ -2128,7 +2132,7 @@ class HayaSelect extends ShapeComponent {
       optionsCountAfter: options.length
     })
 
-    if (!multiple) this.closeOptions({options})
+    if (!multiple || this.p.closeOnChange) this.closeOptions({options})
 
     if (onChange) {
       /** @type {HayaSelectOnChangePayload} */


### PR DESCRIPTION
## Summary
- add a closeOnChange prop that can close multi-select dropdowns after each option click
- cover the controlled multi-select behavior in the example app and system spec
- document the filter-style multi-select use case
- add a root Expo Metro config so expo-doctor recognizes the package root as extending Expo defaults

## Tests
- npm run typecheck
- npm run lint
- npx expo-doctor
- SYSTEM_TEST_HOST=dist npm test -- spec/system/haya-select-render-spec.js