### PR TITLE
Add HayaSelect system-test open and close helpers

### DIFF
--- a/changelog.d/system-test-helper-functions.md
+++ b/changelog.d/system-test-helper-functions.md
@@ -1,1 +1,2 @@
 - Export named HayaSelect system-test helper functions for downstream browser specs.
+- Add named open, close, and close-state helpers for downstream browser specs.

--- a/example/screens/helper-scope-screen.tsx
+++ b/example/screens/helper-scope-screen.tsx
@@ -1,0 +1,25 @@
+import React from "react"
+import {View} from "react-native"
+
+import {Group, HayaSelect, selectOptions, TestScrollView} from "./shared"
+
+export default function HelperScopeScreen() {
+  return (
+    <TestScrollView>
+      <Group name="Helper Scope">
+        <View testID="hayaSelectHelperTargetRoot">
+          <HayaSelect
+            options={selectOptions}
+            placeholder="Pick target"
+          />
+        </View>
+        <View testID="hayaSelectHelperOtherRoot">
+          <HayaSelect
+            options={selectOptions}
+            placeholder="Pick other"
+          />
+        </View>
+      </Group>
+    </TestScrollView>
+  )
+}

--- a/example/screens/index.tsx
+++ b/example/screens/index.tsx
@@ -5,6 +5,7 @@ import CloseOnChangeScreen from "./close-on-change-screen"
 import ControlledValuesScreen from "./controlled-values-screen"
 import DuplicateTestIdSelectScreen from "./duplicate-test-id-select-screen"
 import FilterSelectScreen from "./filter-select-screen"
+import HelperScopeScreen from "./helper-scope-screen"
 import MobileSheetResizeScreen from "./mobile-sheet-resize-screen"
 import MobileSheetSelectScreen from "./mobile-sheet-select-screen"
 import ModuleApiScreen from "./module-api-screen"
@@ -29,6 +30,7 @@ const screens: Record<string, React.ComponentType> = {
   "controlled-values": ControlledValuesScreen,
   "duplicate-test-id-select": DuplicateTestIdSelectScreen,
   "filter-select": FilterSelectScreen,
+  "helper-scope": HelperScopeScreen,
   "mobile-sheet-resize": MobileSheetResizeScreen,
   "mobile-sheet-select": MobileSheetSelectScreen,
   "module-api": ModuleApiScreen,

--- a/spec/system/haya-select-render-spec.js
+++ b/spec/system/haya-select-render-spec.js
@@ -206,12 +206,19 @@ describe("HayaSelect", () => {
 
   it("opens and asserts closed state with named helpers", async () => {
     await runSystemTest(async (systemTest) => {
-      await systemTest.findByTestID("hayaSelectRoot", {timeout: 5000})
+      const otherHelper = new HayaSelectSystemTestHelper({systemTest, testId: "hayaSelectHelperOtherRoot"})
 
-      await openHayaSelect(systemTest, "hayaSelectRoot")
-      await closeHayaSelect(systemTest, "hayaSelectRoot")
-      await expectHayaSelectOptionsClosed(systemTest, "hayaSelectRoot")
-    }, {screen: "basic-select"})
+      await systemTest.findByTestID("hayaSelectHelperTargetRoot", {timeout: 5000})
+      await systemTest.findByTestID("hayaSelectHelperOtherRoot", {timeout: 5000})
+      await openHayaSelect(systemTest, "hayaSelectHelperTargetRoot")
+      await closeHayaSelect(systemTest, "hayaSelectHelperTargetRoot")
+      await openHayaSelect(systemTest, "hayaSelectHelperOtherRoot")
+      await expectHayaSelectOptionsClosed(systemTest, "hayaSelectHelperTargetRoot")
+
+      if (!await otherHelper.isOpen()) {
+        throw new Error("Expected other HayaSelect to stay open while asserting target select is closed")
+      }
+    }, {screen: "helper-scope"})
   })
 
   it("scopes named helper option lookup to the opened select", async () => {

--- a/spec/system/haya-select-render-spec.js
+++ b/spec/system/haya-select-render-spec.js
@@ -4,7 +4,7 @@ import waitFor from "awaitery/build/wait-for.js"
 import {Key} from "selenium-webdriver"
 import {runSystemTest, setupSystemTestLifecycle} from "./system-test-lifecycle.js"
 
-import HayaSelectSystemTestHelper, {clickVisibleHayaSelectOption, expectHayaSelectCurrentOptions, pickHayaSelectOption} from "../../src/system-test-helpers.js"
+import HayaSelectSystemTestHelper, {clickVisibleHayaSelectOption, closeHayaSelect, expectHayaSelectCurrentOptions, expectHayaSelectOptionsClosed, openHayaSelect, pickHayaSelectOption} from "../../src/system-test-helpers.js"
 
 setupSystemTestLifecycle()
 
@@ -202,6 +202,16 @@ describe("HayaSelect", () => {
         await expectHayaSelectCurrentOptions(systemTest, "hayaSelectRoot", ["Two"])
       }, {screen: "filter-select"})
     })
+  })
+
+  it("opens and asserts closed state with named helpers", async () => {
+    await runSystemTest(async (systemTest) => {
+      await systemTest.findByTestID("hayaSelectRoot", {timeout: 5000})
+
+      await openHayaSelect(systemTest, "hayaSelectRoot")
+      await closeHayaSelect(systemTest, "hayaSelectRoot")
+      await expectHayaSelectOptionsClosed(systemTest, "hayaSelectRoot")
+    }, {screen: "basic-select"})
   })
 
   it("scopes named helper option lookup to the opened select", async () => {

--- a/spec/system/haya-select-render-spec.js
+++ b/spec/system/haya-select-render-spec.js
@@ -208,8 +208,8 @@ describe("HayaSelect", () => {
     await runSystemTest(async (systemTest) => {
       const otherHelper = new HayaSelectSystemTestHelper({systemTest, testId: "hayaSelectHelperOtherRoot"})
 
-      await systemTest.findByTestID("hayaSelectHelperTargetRoot", {timeout: 5000})
-      await systemTest.findByTestID("hayaSelectHelperOtherRoot", {timeout: 5000})
+      await systemTest.findByTestID("hayaSelectHelperTargetRoot")
+      await systemTest.findByTestID("hayaSelectHelperOtherRoot")
       await openHayaSelect(systemTest, "hayaSelectHelperTargetRoot")
       await closeHayaSelect(systemTest, "hayaSelectHelperTargetRoot")
       await openHayaSelect(systemTest, "hayaSelectHelperOtherRoot")

--- a/src/system-test-helpers.js
+++ b/src/system-test-helpers.js
@@ -2,9 +2,11 @@ import waitFor from "awaitery/build/wait-for.js"
 import {By} from "selenium-webdriver"
 
 /** @typedef {{systemTest: object, testId: string}} HayaSelectSystemTestHelperOptions */
+/** @typedef {{timeout?: number, useBaseSelector?: boolean}} HayaSelectOpenOptions */
 /** @typedef {{optionText?: string, optionValue?: string | number, search?: boolean, timeout?: number, useBaseSelector?: boolean}} PickHayaSelectOptionOptions */
 /** @typedef {{optionValue: string | number, timeout?: number}} ClickVisibleHayaSelectOptionOptions */
 /** @typedef {{timeout?: number}} ExpectHayaSelectCurrentOptionsOptions */
+/** @typedef {{timeout?: number}} ExpectHayaSelectOptionsClosedOptions */
 /** @typedef {import("selenium-webdriver").WebElement} WebElement */
 
 const DEFAULT_TIMEOUT = 5000
@@ -57,6 +59,32 @@ export async function clickVisibleHayaSelectOption(systemTest, {optionValue, tim
 }
 
 /**
+ * Opens a HayaSelect instance by clicking its select container.
+ * @param {object} systemTest Browser session used by the running spec.
+ * @param {string} testId Wrapper `data-testid` around the select.
+ * @param {HayaSelectOpenOptions} [options] Optional selector scope and timeout.
+ * @returns {Promise<void>} Completes after the select opens.
+ */
+export async function openHayaSelect(systemTest, testId, {timeout = DEFAULT_TIMEOUT, useBaseSelector = true} = {}) {
+  const helper = new HayaSelectSystemTestHelper({systemTest, testId})
+
+  await helper.open({timeout, useBaseSelector})
+}
+
+/**
+ * Closes a HayaSelect instance by clicking its select container.
+ * @param {object} systemTest Browser session used by the running spec.
+ * @param {string} testId Wrapper `data-testid` around the select.
+ * @param {HayaSelectOpenOptions} [options] Optional selector scope and timeout.
+ * @returns {Promise<void>} Completes after the select closes.
+ */
+export async function closeHayaSelect(systemTest, testId, {timeout = DEFAULT_TIMEOUT, useBaseSelector = true} = {}) {
+  const helper = new HayaSelectSystemTestHelper({systemTest, testId})
+
+  await helper.close({timeout, useBaseSelector})
+}
+
+/**
  * Waits until a HayaSelect renders exactly the expected current-option labels.
  * @param {object} systemTest Browser session used by the running spec.
  * @param {string} testId Wrapper `data-testid` around the select.
@@ -90,6 +118,19 @@ export async function expectHayaSelectCurrentOptions(systemTest, testId, expecte
 }
 
 /**
+ * Waits until a HayaSelect and its portal-rendered options are closed.
+ * @param {object} systemTest Browser session used by the running spec.
+ * @param {string} testId Wrapper `data-testid` around the select.
+ * @param {ExpectHayaSelectOptionsClosedOptions} [options] Optional Selenium timeout override.
+ * @returns {Promise<void>} Completes after no visible options remain.
+ */
+export async function expectHayaSelectOptionsClosed(systemTest, testId, {timeout = DEFAULT_TIMEOUT} = {}) {
+  const helper = new HayaSelectSystemTestHelper({systemTest, testId})
+
+  await helper.expectClosed({timeout})
+}
+
+/**
  * System test helper for interacting with HayaSelect instances.
  */
 export default class HayaSelectSystemTestHelper {
@@ -116,12 +157,15 @@ export default class HayaSelectSystemTestHelper {
     this.optionsContainerSelectorFallback = "[data-testid='haya-select/options-container']"
   }
 
-  /** @returns {Promise<void>} */
-  async open() {
-    await this.clickSelectContainer()
+  /**
+   * @param {HayaSelectOpenOptions} [options] Optional selector scope and timeout.
+   * @returns {Promise<void>} Completes after the select opens.
+   */
+  async open({timeout = DEFAULT_TIMEOUT, useBaseSelector = true} = {}) {
+    await this.clickSelectContainer({timeout, useBaseSelector})
     this._optionsContainerSelector = null
 
-    await waitFor({timeout: 5000}, async () => {
+    await waitFor({timeout}, async () => {
       const openedElements = await this.findElements(`${this.componentSelector}[data-opened='true']`)
 
       if (openedElements.length === 0) {
@@ -130,15 +174,34 @@ export default class HayaSelectSystemTestHelper {
     })
   }
 
-  /** @returns {Promise<void>} */
-  async close() {
-    await this.clickSelectContainer()
+  /**
+   * @param {HayaSelectOpenOptions} [options] Optional selector scope and timeout.
+   * @returns {Promise<void>} Completes after the select closes.
+   */
+  async close({timeout = DEFAULT_TIMEOUT, useBaseSelector = true} = {}) {
+    await this.clickSelectContainer({timeout, useBaseSelector})
 
-    await waitFor({timeout: 5000}, async () => {
+    await waitFor({timeout}, async () => {
       const openedElements = await this.findElements(`${this.componentSelector}[data-opened='true']`)
 
       if (openedElements.length > 0) {
         throw new Error(`Expected HayaSelect to close: ${this.testId}`)
+      }
+    })
+  }
+
+  /**
+   * @param {ExpectHayaSelectOptionsClosedOptions} [options] Optional timeout.
+   * @returns {Promise<void>} Completes after no visible options remain.
+   */
+  async expectClosed({timeout = DEFAULT_TIMEOUT} = {}) {
+    await waitFor({timeout}, async () => {
+      const open = await this.isOpen()
+      const visibleContainersCount = (await this.findVisibleElements("[data-testid='haya-select/options-container']")).length
+      const visibleOptionsCount = (await this.findVisibleElements("[data-testid='haya-select/option']")).length
+
+      if (open || visibleContainersCount > 0 || visibleOptionsCount > 0) {
+        throw new Error(`Expected ${this.testId} options to close, got open=${open}, visibleContainers=${visibleContainersCount}, visibleOptions=${visibleOptionsCount}`)
       }
     })
   }
@@ -154,9 +217,12 @@ export default class HayaSelectSystemTestHelper {
     return searchInputs.length > 0
   }
 
-  /** @returns {Promise<void>} */
-  async clickSelectContainer() {
-    const selectContainer = await this.systemTest.find(this.selectContainerSelector, {timeout: 5000})
+  /**
+   * @param {HayaSelectOpenOptions} [options] Optional selector scope and timeout.
+   * @returns {Promise<void>} Completes after the select container click.
+   */
+  async clickSelectContainer({timeout = DEFAULT_TIMEOUT, useBaseSelector = true} = {}) {
+    const selectContainer = await this.systemTest.find(this.selectContainerSelector, {timeout, useBaseSelector})
 
     await selectContainer.click()
   }

--- a/src/system-test-helpers.js
+++ b/src/system-test-helpers.js
@@ -196,9 +196,10 @@ export default class HayaSelectSystemTestHelper {
    */
   async expectClosed({timeout = DEFAULT_TIMEOUT} = {}) {
     await waitFor({timeout}, async () => {
+      const optionsContainerSelector = await this.optionsContainerSelector()
       const open = await this.isOpen()
-      const visibleContainersCount = (await this.findVisibleElements("[data-testid='haya-select/options-container']")).length
-      const visibleOptionsCount = (await this.findVisibleElements("[data-testid='haya-select/option']")).length
+      const visibleContainersCount = await this.visibleElementsCount(optionsContainerSelector)
+      const visibleOptionsCount = await this.visibleElementsCount(`${optionsContainerSelector} [data-testid='haya-select/option']`)
 
       if (open || visibleContainersCount > 0 || visibleOptionsCount > 0) {
         throw new Error(`Expected ${this.testId} options to close, got open=${open}, visibleContainers=${visibleContainersCount}, visibleOptions=${visibleOptionsCount}`)
@@ -250,6 +251,25 @@ export default class HayaSelectSystemTestHelper {
     }
 
     return visibleElements
+  }
+
+  /**
+   * Counts visible elements by CSS selector in browser layout state.
+   * @param {string} selector CSS selector to count.
+   * @returns {Promise<number>} Number of visible elements.
+   */
+  async visibleElementsCount(selector) {
+    return Number(
+      await this.systemTest.getDriver().executeScript(
+        `
+          return Array.from(document.querySelectorAll(arguments[0])).filter((element) => {
+            const style = window.getComputedStyle(element)
+            return style.display !== "none" && style.visibility !== "hidden" && element.getClientRects().length > 0
+          }).length
+        `,
+        selector
+      )
+    )
   }
 
   /** @returns {Promise<string>} */


### PR DESCRIPTION
Adds named system-test helpers for opening, closing, and asserting closed HayaSelect options so downstream projects do not need local helper copies.\n\nValidation:\n- npm run lint\n- npm run typecheck\n- npm run build\n- SKIP_TEST_DIST_BUILD=true SYSTEM_TEST_HOST=dist npx velocious test spec/system/haya-select-render-spec.js